### PR TITLE
Prefer previewing via Icon over Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ private var _Add: ImageVector? = null
 
 ```kotlin
 import androidx.compose.runtime.Composable
-import androidx.compose.foundation.Image
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap

--- a/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/util/PreviewSpec.kt
+++ b/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/util/PreviewSpec.kt
@@ -28,7 +28,7 @@ internal fun iconPreviewSpecForNestedPack(
             )
             addStatement(
                 format = "%M(imageVector = %T, contentDescription = null)",
-                MemberNames.Image,
+                MemberNames.Icon,
                 iconPackClassName.nestedClass(iconName)
             )
             endControlFlow()
@@ -54,7 +54,7 @@ internal fun iconPreviewSpec(
             )
             addStatement(
                 format = "%M(imageVector = %M, contentDescription = null)",
-                MemberNames.Image,
+                MemberNames.Icon,
                 MemberName(
                     packageName = iconPackage,
                     simpleName = iconName

--- a/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/PreviewGenerationTest.kt
+++ b/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/PreviewGenerationTest.kt
@@ -24,9 +24,9 @@ class PreviewGenerationTest {
         val expectedOutput = """
             package io.github.composegears.valkyrie.icons
 
-            import androidx.compose.foundation.Image
             import androidx.compose.foundation.layout.Box
             import androidx.compose.foundation.layout.padding
+            import androidx.compose.material3.Icon
             import androidx.compose.runtime.Composable
             import androidx.compose.ui.Modifier
             import androidx.compose.ui.graphics.vector.ImageVector
@@ -55,7 +55,7 @@ class PreviewGenerationTest {
             @Composable
             private fun WithoutPathPreview() {
                 Box(modifier = Modifier.padding(12.dp)) {
-                    Image(imageVector = WithoutPath, contentDescription = null)
+                    Icon(imageVector = WithoutPath, contentDescription = null)
                 }
             }
 
@@ -81,9 +81,9 @@ class PreviewGenerationTest {
         val expectedOutput = """
             package io.github.composegears.valkyrie.icons
 
-            import androidx.compose.foundation.Image
             import androidx.compose.foundation.layout.Box
             import androidx.compose.foundation.layout.padding
+            import androidx.compose.material3.Icon
             import androidx.compose.runtime.Composable
             import androidx.compose.ui.Modifier
             import androidx.compose.ui.graphics.vector.ImageVector
@@ -112,7 +112,7 @@ class PreviewGenerationTest {
             @Composable
             private fun WithoutPathPreview() {
                 Box(modifier = Modifier.padding(12.dp)) {
-                    Image(imageVector = ValkyrieIcons.WithoutPath, contentDescription = null)
+                    Icon(imageVector = ValkyrieIcons.WithoutPath, contentDescription = null)
                 }
             }
 
@@ -138,9 +138,9 @@ class PreviewGenerationTest {
         val expectedOutput = """
             package io.github.composegears.valkyrie.icons.filled
 
-            import androidx.compose.foundation.Image
             import androidx.compose.foundation.layout.Box
             import androidx.compose.foundation.layout.padding
+            import androidx.compose.material3.Icon
             import androidx.compose.runtime.Composable
             import androidx.compose.ui.Modifier
             import androidx.compose.ui.graphics.vector.ImageVector
@@ -170,7 +170,7 @@ class PreviewGenerationTest {
             @Composable
             private fun WithoutPathPreview() {
                 Box(modifier = Modifier.padding(12.dp)) {
-                    Image(imageVector = ValkyrieIcons.Filled.WithoutPath, contentDescription = null)
+                    Icon(imageVector = ValkyrieIcons.Filled.WithoutPath, contentDescription = null)
                 }
             }
 

--- a/components/google/src/main/kotlin/androidx/compose/material/icons/generator/Names.kt
+++ b/components/google/src/main/kotlin/androidx/compose/material/icons/generator/Names.kt
@@ -32,6 +32,7 @@ internal enum class PackageNames(val packageName: String) {
     LayoutPackage(FoundationPackage.packageName + ".layout"),
     PreviewPackage(UiPackage.packageName + ".tooling.preview"),
     RuntimePackage("androidx.compose.runtime"),
+    Material3Package("androidx.compose.material3")
 }
 
 /**
@@ -62,7 +63,7 @@ object MemberNames {
     val Modifier = MemberName(PackageNames.UiPackage.packageName, "Modifier")
     val Padding = MemberName(PackageNames.LayoutPackage.packageName, "padding")
     val Box = MemberName(PackageNames.LayoutPackage.packageName, "Box")
-    val Image = MemberName(PackageNames.FoundationPackage.packageName, "Image")
+    val Icon = MemberName(PackageNames.Material3Package.packageName, "Icon")
 
     val Color = MemberName(PackageNames.GraphicsPackage.packageName, "Color")
     val SolidColor = MemberName(PackageNames.GraphicsPackage.packageName, "SolidColor")

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/IconPreviewBox.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/IconPreviewBox.kt
@@ -1,13 +1,13 @@
 package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -62,7 +62,7 @@ fun IconPreviewBox(painter: Painter) {
                 )
             }
         }
-        Image(
+        Icon(
             modifier = Modifier.size(36.dp),
             painter = painter,
             contentDescription = null


### PR DESCRIPTION
- `ImageVectors` are typically used for simple icons, which are preferably displayed using `Icon`.
- And the current image preview in my project is totally a white screen, it seems to be a bug here? `Icon` works well as it contains a default tint.