### PR TITLE
Fully migrate file opeartions to using nio Path

### DIFF
--- a/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/Common.kt
+++ b/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/Common.kt
@@ -1,6 +1,6 @@
 package io.github.composegears.valkyrie.generator.imagevector
 
-import java.io.File
+import kotlin.io.path.Path
 
 val DEFAULT_CONFIG = ImageVectorGeneratorConfig(
     packageName = "io.github.composegears.valkyrie.icons",
@@ -9,4 +9,4 @@ val DEFAULT_CONFIG = ImageVectorGeneratorConfig(
     generatePreview = false
 )
 
-fun loadIcon(name: String) = File("src/test/resources/${name}")
+fun loadIcon(name: String) = Path("src/test/resources/${name}")

--- a/components/parser/build.gradle.kts
+++ b/components/parser/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 dependencies {
     api(projects.components.google)
 
+    // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
+    compileOnly(libs.kotlin.stdlib)
+
     implementation(libs.android.build.tools)
 
     testImplementation(libs.kotlin.test)

--- a/components/parser/build.gradle.kts
+++ b/components/parser/build.gradle.kts
@@ -6,7 +6,6 @@ dependencies {
     api(projects.components.google)
 
     implementation(libs.android.build.tools)
-    implementation(libs.kotlin.io)
 
     testImplementation(libs.kotlin.test)
 }

--- a/components/parser/src/main/kotlin/io/github/composegears/valkyrie/parser/IconParser.kt
+++ b/components/parser/src/main/kotlin/io/github/composegears/valkyrie/parser/IconParser.kt
@@ -5,9 +5,11 @@ import androidx.compose.material.icons.generator.IconParser
 import androidx.compose.material.icons.generator.vector.Vector
 import io.github.composegears.valkyrie.parser.IconType.SVG
 import io.github.composegears.valkyrie.parser.IconType.XML
-import java.io.File
+import java.nio.file.Path
 import java.util.*
 import kotlin.io.path.createTempFile
+import kotlin.io.path.extension
+import kotlin.io.path.name
 import kotlin.io.path.readText
 
 data class IconParserOutput(
@@ -18,18 +20,18 @@ data class IconParserOutput(
 object IconParser {
 
     @Throws(IllegalStateException::class)
-    fun toVector(file: File): IconParserOutput {
-        val iconType = IconTypeParser.getIconType(file.extension) ?: error("File not SVG or XML")
+    fun toVector(path: Path): IconParserOutput {
+        val iconType = IconTypeParser.getIconType(path.extension) ?: error("File not SVG or XML")
 
-        val fileName = getIconName(fileName = file.name)
+        val fileName = getIconName(fileName = path.name)
         val icon = when (iconType) {
             SVG -> {
-                val tmpFile = createTempFile(suffix = "valkyrie/")
-                SvgToXmlParser.parse(file, tmpFile)
+                val tmpPath = createTempFile(suffix = "valkyrie/")
+                SvgToXmlParser.parse(path, tmpPath)
 
-                Icon(fileContent = tmpFile.readText())
+                Icon(fileContent = tmpPath.readText())
             }
-            XML -> Icon(fileContent = file.readText())
+            XML -> Icon(fileContent = path.readText())
         }
 
         return IconParserOutput(

--- a/components/parser/src/main/kotlin/io/github/composegears/valkyrie/parser/SvgToXmlParser.kt
+++ b/components/parser/src/main/kotlin/io/github/composegears/valkyrie/parser/SvgToXmlParser.kt
@@ -1,13 +1,12 @@
 package io.github.composegears.valkyrie.parser
 
 import com.android.ide.common.vectordrawable.Svg2Vector
-import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.outputStream
 
 object SvgToXmlParser {
 
-    fun parse(file: File, outPath: Path) {
-        Svg2Vector.parseSvgToXml(file.toPath(), outPath.outputStream())
+    fun parse(input: Path, output: Path) {
+        Svg2Vector.parseSvgToXml(input, output.outputStream())
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,6 @@ org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx4g
 org.gradle.parallel=true
 
+# https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
+kotlin.stdlib.default.dependency=false
 kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,4 @@ org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx4g
 org.gradle.parallel=true
 
-kotlin.stdlib.default.dependency=false
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,6 @@ android-build-tools = "com.android.tools:sdk-common:31.5.1"
 
 koin-compose = "io.insert-koin:koin-compose:1.1.5"
 
-kotlin-io = "org.jetbrains.kotlinx:kotlinx-io-core:0.5.1"
-
 kotlinpoet = "com.squareup:kotlinpoet:1.18.1"
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ android-build-tools = "com.android.tools:sdk-common:31.5.1"
 koin-compose = "io.insert-koin:koin-compose:1.1.5"
 
 kotlinpoet = "com.squareup:kotlinpoet:1.18.1"
+
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 
 tiamat = "io.github.composegears:tiamat:1.1.0-rc02"

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/processing/writter/FileWriter.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/processing/writter/FileWriter.kt
@@ -1,22 +1,21 @@
 package io.github.composegears.valkyrie.processing.writter
 
+import java.io.IOException
 import kotlin.io.path.Path
-import kotlin.io.path.createDirectories
-import kotlin.io.path.outputStream
+import kotlin.io.path.createParentDirectories
+import kotlin.io.path.writeText
+import kotlin.jvm.Throws
 
 object FileWriter {
 
+    @Throws(IOException::class)
     fun writeToFile(
         content: String,
         outDirectory: String,
         fileName: String,
     ) {
         val outPath = Path("$outDirectory/$fileName.kt")
-        outPath.parent.createDirectories()
-
-        outPath.outputStream().bufferedWriter()
-            .use {
-                it.write(content)
-            }
+        outPath.createParentDirectories()
+        outPath.writeText(content)
     }
 }

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/extension/VirtualFile.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/extension/VirtualFile.kt
@@ -1,6 +1,7 @@
 package io.github.composegears.valkyrie.ui.extension
 
 import com.intellij.openapi.vfs.VirtualFile
-import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.Path
 
-fun VirtualFile.toFile() = File(path)
+fun VirtualFile.toPath(): Path = Path(path)

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/dnd/DragAndDropHandler.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/dnd/DragAndDropHandler.kt
@@ -15,6 +15,7 @@ import java.awt.dnd.DropTargetDragEvent
 import java.awt.dnd.DropTargetDropEvent
 import java.awt.dnd.DropTargetEvent
 import java.awt.dnd.DropTargetListener
+import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.isDirectory
 
@@ -93,8 +94,8 @@ private class SimpleDropTargetListener(
             .filter { it.isFlavorJavaFileListType }
             .mapNotNull { transferable.getTransferData(it) as? List<*> }
             .flatten()
-            .filterIsInstance<java.io.File>()
-            .map { it.toPath() }
+            .filterIsInstance<File>()
+            .map(File::toPath)
             .toList()
 
         onDrop(paths)

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/picker/DirectoryPicker.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/picker/DirectoryPicker.kt
@@ -10,20 +10,21 @@ import com.intellij.openapi.project.Project
 import io.github.composegears.valkyrie.ui.foundation.theme.LocalProject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.nio.file.Path
 
 @Composable
-fun rememberDirectoryPicker(): Picker<String?> {
+fun rememberDirectoryPicker(): Picker<Path?> {
     if (LocalInspectionMode.current) return StubDirectoryPicker
 
     val project = LocalProject.current
     return remember { DirectoryPicker(project = project) }
 }
 
-private object StubDirectoryPicker : Picker<String?> {
-    override suspend fun launch(): String? = null
+private object StubDirectoryPicker : Picker<Path?> {
+    override suspend fun launch(): Path? = null
 }
 
-private class DirectoryPicker(private val project: Project) : Picker<String?> {
+private class DirectoryPicker(private val project: Project) : Picker<Path?> {
 
     private val fileChooserDescriptor = FileChooserDescriptor(
         /* chooseFiles = */ false,
@@ -34,7 +35,7 @@ private class DirectoryPicker(private val project: Project) : Picker<String?> {
         /* chooseMultiple = */ false
     )
 
-    override suspend fun launch(): String? = withContext(Dispatchers.EDT) {
-        FileChooser.chooseFile(fileChooserDescriptor, project, null)?.path
+    override suspend fun launch(): Path? = withContext(Dispatchers.EDT) {
+        FileChooser.chooseFile(fileChooserDescriptor, project, null)?.toNioPath()
     }
 }

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/picker/FilePicker.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/picker/FilePicker.kt
@@ -11,14 +11,14 @@ import com.intellij.openapi.util.Condition
 import com.intellij.openapi.vfs.VirtualFile
 import io.github.composegears.valkyrie.ui.extension.isSvg
 import io.github.composegears.valkyrie.ui.extension.isXml
-import io.github.composegears.valkyrie.ui.extension.toFile
+import io.github.composegears.valkyrie.ui.extension.toPath
 import io.github.composegears.valkyrie.ui.foundation.theme.LocalProject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.File
+import java.nio.file.Path
 
 @Composable
-fun rememberFilePicker(): Picker<File?> {
+fun rememberFilePicker(): Picker<Path?> {
     if (LocalInspectionMode.current) return StubFilePicker
 
     val project = LocalProject.current
@@ -26,8 +26,8 @@ fun rememberFilePicker(): Picker<File?> {
     return remember {
         FilePicker(
             project = project,
-            filterCondition = { file ->
-                val extension = file.extension
+            filterCondition = { path ->
+                val extension = path.extension
 
                 extension != null && (extension.isSvg() || extension.isXml())
             }
@@ -35,14 +35,14 @@ fun rememberFilePicker(): Picker<File?> {
     }
 }
 
-private object StubFilePicker : Picker<File?> {
-    override suspend fun launch(): File? = null
+private object StubFilePicker : Picker<Path?> {
+    override suspend fun launch(): Path? = null
 }
 
 private class FilePicker(
     private val project: Project,
     filterCondition: Condition<VirtualFile> = Condition { true }
-) : Picker<File?> {
+) : Picker<Path?> {
 
     private val fileChooserDescriptor = FileChooserDescriptor(
         /* chooseFiles = */ true,
@@ -53,9 +53,9 @@ private class FilePicker(
         /* chooseMultiple = */ false
     ).withFileFilter(filterCondition)
 
-    override suspend fun launch() = withContext(Dispatchers.EDT) {
+    override suspend fun launch(): Path? = withContext(Dispatchers.EDT) {
         FileChooser
             .chooseFile(fileChooserDescriptor, project, null)
-            ?.toFile()
+            ?.toPath()
     }
 }

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/picker/MultipleFilesPicker.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/picker/MultipleFilesPicker.kt
@@ -11,14 +11,13 @@ import com.intellij.openapi.util.Condition
 import com.intellij.openapi.vfs.VirtualFile
 import io.github.composegears.valkyrie.ui.extension.isSvg
 import io.github.composegears.valkyrie.ui.extension.isXml
-import io.github.composegears.valkyrie.ui.extension.toFile
 import io.github.composegears.valkyrie.ui.foundation.theme.LocalProject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.File
+import java.nio.file.Path
 
 @Composable
-fun rememberMultipleFilesPicker(): Picker<List<File>> {
+fun rememberMultipleFilesPicker(): Picker<List<Path>> {
     if (LocalInspectionMode.current) return StubMultipleFilesPicker
 
     val project = LocalProject.current
@@ -26,8 +25,8 @@ fun rememberMultipleFilesPicker(): Picker<List<File>> {
     return remember {
         MultipleFilesPicker(
             project = project,
-            filterCondition = { file ->
-                val extension = file.extension
+            filterCondition = { path ->
+                val extension = path.extension
 
                 extension != null && (extension.isSvg() || extension.isXml())
             }
@@ -35,14 +34,14 @@ fun rememberMultipleFilesPicker(): Picker<List<File>> {
     }
 }
 
-private object StubMultipleFilesPicker : Picker<List<File>> {
-    override suspend fun launch(): List<File> = emptyList()
+private object StubMultipleFilesPicker : Picker<List<Path>> {
+    override suspend fun launch(): List<Path> = emptyList()
 }
 
 private class MultipleFilesPicker(
     private val project: Project,
     filterCondition: Condition<VirtualFile> = Condition { true }
-) : Picker<List<File>> {
+) : Picker<List<Path>> {
 
     private val fileChooserDescriptor = FileChooserDescriptor(
         /* chooseFiles = */ true,
@@ -53,9 +52,9 @@ private class MultipleFilesPicker(
         /* chooseMultiple = */ true
     ).withFileFilter(filterCondition)
 
-    override suspend fun launch(): List<File> = withContext(Dispatchers.EDT) {
+    override suspend fun launch(): List<Path> = withContext(Dispatchers.EDT) {
         FileChooser
             .chooseFiles(fileChooserDescriptor, project, null)
-            .map(VirtualFile::toFile)
+            .map(VirtualFile::toNioPath)
     }
 }

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionState.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionState.kt
@@ -1,7 +1,7 @@
 package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion
 
 import androidx.compose.ui.graphics.painter.Painter
-import java.io.File
+import java.nio.file.Path
 
 sealed interface IconPackConversionState {
 
@@ -35,7 +35,7 @@ sealed interface BatchIcon {
         override val iconName: IconName,
         override val extension: String,
         val painter: Painter,
-        val file: File
+        val path: Path
     ) : BatchIcon
 }
 

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/BatchProcessingState.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/BatchProcessingState.kt
@@ -48,7 +48,7 @@ import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconPa
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.FileTypeBadge
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.IconNameField
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.IconPreviewBox
-import java.io.File
+import kotlin.io.path.Path
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -308,7 +308,7 @@ private fun BatchProcessingStatePreview() = PreviewTheme {
             BatchIcon.Valid(
                 iconName = IconName(IconParser.getIconName("ic_all_path_params_1")),
                 extension = "xml",
-                file = File(""),
+                path = Path(""),
                 iconPack = IconPack.Single(
                     iconPackage = "package",
                     iconPackName = "ValkyrieIcons"
@@ -322,7 +322,7 @@ private fun BatchProcessingStatePreview() = PreviewTheme {
             BatchIcon.Valid(
                 iconName = IconName(IconParser.getIconName("ic_all_path")),
                 extension = "svg",
-                file = File(""),
+                path = Path(""),
                 iconPack = IconPack.Nested(
                     iconPackName = "ValkyrieIcons",
                     iconPackage = "package",

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/IconPackPickerState.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/IconPackPickerState.kt
@@ -38,7 +38,9 @@ import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.Picker
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.PickerEvent.PickDirectory
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.PickerEvent.PickFiles
 import kotlinx.coroutines.launch
-import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
 
 @Composable
 fun IconPackPickerState(onPickerEvent: (PickerEvent) -> Unit) {
@@ -52,17 +54,17 @@ fun IconPackPickerState(onPickerEvent: (PickerEvent) -> Unit) {
         contentAlignment = Alignment.Center
     ) {
         SelectableState(
-            onSelectFile = { files ->
+            onSelectPath = { paths ->
                 when {
-                    files.size == 1 -> {
-                        val file = files.first()
+                    paths.size == 1 -> {
+                        val path = paths.first()
 
                         when {
-                            file.isDirectory -> onPickerEvent(PickDirectory(path = file.path))
-                            file.isFile -> onPickerEvent(PickFiles(files = files))
+                            path.isDirectory() -> onPickerEvent(PickDirectory(path = path))
+                            path.isRegularFile() -> onPickerEvent(PickFiles(paths = paths))
                         }
                     }
-                    else -> onPickerEvent(PickFiles(files = files))
+                    else -> onPickerEvent(PickFiles(paths = paths))
                 }
             },
             onPickDirectory = {
@@ -76,10 +78,10 @@ fun IconPackPickerState(onPickerEvent: (PickerEvent) -> Unit) {
             },
             onPickFiles = {
                 scope.launch {
-                    val files = multipleFilePicker.launch()
+                    val paths = multipleFilePicker.launch()
 
-                    if (files.isNotEmpty()) {
-                        onPickerEvent(PickFiles(files = files))
+                    if (paths.isNotEmpty()) {
+                        onPickerEvent(PickFiles(paths = paths))
                     }
                 }
             }
@@ -92,9 +94,9 @@ fun IconPackPickerState(onPickerEvent: (PickerEvent) -> Unit) {
 private fun SelectableState(
     onPickDirectory: () -> Unit,
     onPickFiles: () -> Unit,
-    onSelectFile: (List<File>) -> Unit
+    onSelectPath: (List<Path>) -> Unit
 ) {
-    val dragAndDropHandler = rememberMultiSelectDragAndDropHandler(onDrop = onSelectFile)
+    val dragAndDropHandler = rememberMultiSelectDragAndDropHandler(onDrop = onSelectPath)
     val isDragging by rememberMutableState(dragAndDropHandler.isDragging) { dragAndDropHandler.isDragging }
 
     DragAndDropBox(isDragging = isDragging) {

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/util/FileToPainter.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/util/FileToPainter.kt
@@ -4,17 +4,19 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.toPainter
 import com.android.ide.common.vectordrawable.VdPreview
 import io.github.composegears.valkyrie.parser.SvgToXmlParser
-import java.io.File
+import java.nio.file.Path
 import kotlin.io.path.createTempFile
+import kotlin.io.path.extension
+import kotlin.io.path.name
 import kotlin.io.path.readText
 
-fun File.toPainterOrNull(): Painter? = when (extension) {
+fun Path.toPainterOrNull(): Painter? = when (extension) {
     "svg" -> svgToPainter()
     "xml" -> xmlToPainter()
     else -> error("Unsupported file type: $extension")
 }
 
-private fun File.svgToPainter(): Painter? {
+private fun Path.svgToPainter(): Painter? {
     return runCatching {
         val outPath = createTempFile(name, extension)
         SvgToXmlParser.parse(this, outPath)
@@ -27,7 +29,7 @@ private fun File.svgToPainter(): Painter? {
     }.getOrElse { null }
 }
 
-private fun File.xmlToPainter(): Painter? = runCatching {
+private fun Path.xmlToPainter(): Painter? = runCatching {
     VdPreview.getPreviewFromVectorXml(
         VdPreview.TargetSize.createFromScale(5.0),
         this.readText(),

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/destination/IconPackDestinationScreen.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/destination/IconPackDestinationScreen.kt
@@ -40,6 +40,7 @@ import io.github.composegears.valkyrie.ui.foundation.picker.rememberDirectoryPic
 import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.creation.IconPackCreationScreen
 import kotlinx.coroutines.launch
+import kotlin.io.path.absolutePathString
 
 val IconPackDestinationScreen by navDestination<Unit> {
     val navController = navController()
@@ -47,7 +48,9 @@ val IconPackDestinationScreen by navDestination<Unit> {
 
     val state by viewModel.state.collectAsState()
 
-    val dragAndDropHandler = rememberDragAndDropFolderHandler(onDrop = viewModel::updateDestination)
+    val dragAndDropHandler = rememberDragAndDropFolderHandler {
+        viewModel.updateDestination(it.absolutePathString())
+    }
     val isDragging by remember(dragAndDropHandler.isDragging) { mutableStateOf(dragAndDropHandler.isDragging) }
 
     val scope = rememberCoroutineScope()
@@ -61,7 +64,7 @@ val IconPackDestinationScreen by navDestination<Unit> {
                 val path = directoryPicker.launch()
 
                 if (path != null) {
-                    viewModel.updateDestination(path)
+                    viewModel.updateDestination(path.absolutePathString())
                 }
             }
         },

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/destination/IconPackDestinationScreen.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/destination/IconPackDestinationScreen.kt
@@ -48,9 +48,7 @@ val IconPackDestinationScreen by navDestination<Unit> {
 
     val state by viewModel.state.collectAsState()
 
-    val dragAndDropHandler = rememberDragAndDropFolderHandler {
-        viewModel.updateDestination(it.absolutePathString())
-    }
+    val dragAndDropHandler = rememberDragAndDropFolderHandler(onDrop = viewModel::updateDestination)
     val isDragging by remember(dragAndDropHandler.isDragging) { mutableStateOf(dragAndDropHandler.isDragging) }
 
     val scope = rememberCoroutineScope()
@@ -64,7 +62,7 @@ val IconPackDestinationScreen by navDestination<Unit> {
                 val path = directoryPicker.launch()
 
                 if (path != null) {
-                    viewModel.updateDestination(path.absolutePathString())
+                    viewModel.updateDestination(path)
                 }
             }
         },

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/destination/IconPackDestinationViewModel.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/destination/IconPackDestinationViewModel.kt
@@ -5,6 +5,8 @@ import io.github.composegears.valkyrie.settings.InMemorySettings
 import io.github.composegears.valkyrie.ui.extension.updateState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
 
 class IconPackDestinationViewModel(
     private val inMemorySettings: InMemorySettings
@@ -20,10 +22,10 @@ class IconPackDestinationViewModel(
     )
     val state = _state.asStateFlow()
 
-    fun updateDestination(destination: String) {
+    fun updateDestination(path: Path) {
         _state.updateState {
             copy(
-                iconPackDestination = destination,
+                iconPackDestination = path.absolutePathString(),
                 nextButtonEnabled = true
             )
         }

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/SimpleConversionScreen.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/SimpleConversionScreen.kt
@@ -38,7 +38,7 @@ import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
 import io.github.composegears.valkyrie.ui.screen.settings.SettingsScreen
 import kotlinx.coroutines.launch
 import java.awt.datatransfer.StringSelection
-import java.io.File
+import java.nio.file.Path
 
 val SimpleConversionScreen by navDestination<Unit> {
     val navController = navController()
@@ -48,7 +48,7 @@ val SimpleConversionScreen by navDestination<Unit> {
 
     ConversionUi(
         state = state,
-        onSelectFile = viewModel::selectFile,
+        onSelectPath = viewModel::selectPath,
         openSettings = {
             navController.navigate(
                 dest = SettingsScreen,
@@ -62,7 +62,7 @@ val SimpleConversionScreen by navDestination<Unit> {
 @Composable
 private fun ConversionUi(
     state: SimpleConversionState,
-    onSelectFile: (File) -> Unit,
+    onSelectPath: (Path) -> Unit,
     openSettings: () -> Unit,
     resetIconContent: () -> Unit
 ) {
@@ -72,12 +72,12 @@ private fun ConversionUi(
 
     PluginUI(
         content = state.iconContent,
-        onChooseFile = {
+        onChoosePath = {
             scope.launch {
-                val file = filePicker.launch()
+                val path = filePicker.launch()
 
-                if (file != null) {
-                    onSelectFile(file)
+                if (path != null) {
+                    onSelectPath(path)
                 }
             }
         },
@@ -87,7 +87,7 @@ private fun ConversionUi(
             CopyPasteManager.getInstance().setContents(StringSelection(text))
             notificationManager.show("Copied in clipboard")
         },
-        onSelectFile = onSelectFile,
+        onSelectPath = onSelectPath,
         openSettings = openSettings
     )
 }
@@ -95,10 +95,10 @@ private fun ConversionUi(
 @Composable
 private fun PluginUI(
     content: String?,
-    onChooseFile: () -> Unit,
+    onChoosePath: () -> Unit,
     onClear: () -> Unit,
     onCopy: () -> Unit,
-    onSelectFile: (File) -> Unit,
+    onSelectPath: (Path) -> Unit,
     openSettings: () -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
@@ -123,8 +123,8 @@ private fun PluginUI(
                 contentAlignment = Alignment.Center
             ) {
                 SelectableState(
-                    onSelectFile = onSelectFile,
-                    onChooseFile = onChooseFile
+                    onSelectPath = onSelectPath,
+                    onChoosePath = onChoosePath
                 )
             }
         }
@@ -133,15 +133,15 @@ private fun PluginUI(
 
 @Composable
 private fun SelectableState(
-    onChooseFile: () -> Unit,
-    onSelectFile: (File) -> Unit
+    onChoosePath: () -> Unit,
+    onSelectPath: (Path) -> Unit
 ) {
-    val dragAndDropHandler = rememberFileDragAndDropHandler(onDrop = onSelectFile)
+    val dragAndDropHandler = rememberFileDragAndDropHandler(onDrop = onSelectPath)
     val isDragging by rememberMutableState(dragAndDropHandler.isDragging) { dragAndDropHandler.isDragging }
 
     DragAndDropBox(
         isDragging = isDragging,
-        onChoose = onChooseFile
+        onChoose = onChoosePath
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Icon(
@@ -166,7 +166,7 @@ private fun SelectableState(
 private fun SimpleConversionScreenPreview() = PreviewTheme {
     ConversionUi(
         state = SimpleConversionState(),
-        onSelectFile = {},
+        onSelectPath = {},
         openSettings = {},
         resetIconContent = {}
     )

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/SimpleConversionState.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/SimpleConversionState.kt
@@ -1,8 +1,8 @@
 package io.github.composegears.valkyrie.ui.screen.mode.simple.conversion
 
-import java.io.File
+import java.nio.file.Path
 
 data class SimpleConversionState(
-    val lastFile: File? = null,
+    val lastPath: Path? = null,
     val iconContent: String? = null
 )

--- a/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/SimpleConversionViewModel.kt
+++ b/plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/SimpleConversionViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
-import java.io.File
+import java.nio.file.Path
 
 class SimpleConversionViewModel(inMemorySettings: InMemorySettings) : TiamatViewModel() {
 
@@ -21,16 +21,16 @@ class SimpleConversionViewModel(inMemorySettings: InMemorySettings) : TiamatView
     init {
         _state
             .combine(inMemorySettings.settings) { state, settings ->
-                if (state.lastFile != null) {
-                    updateIcon(state.lastFile, settings)
+                if (state.lastPath != null) {
+                    updateIcon(state.lastPath, settings)
                 }
             }
             .launchIn(viewModelScope)
     }
 
-    private fun updateIcon(file: File, valkyriesSettings: ValkyriesSettings) {
+    private fun updateIcon(path: Path, valkyriesSettings: ValkyriesSettings) {
         val output = runCatching {
-            val parserOutput = IconParser.toVector(file)
+            val parserOutput = IconParser.toVector(path)
             ImageVectorGenerator.convert(
                 vector = parserOutput.vector,
                 kotlinName = parserOutput.kotlinName,
@@ -48,11 +48,11 @@ class SimpleConversionViewModel(inMemorySettings: InMemorySettings) : TiamatView
         _state.updateState { copy(iconContent = output) }
     }
 
-    fun selectFile(file: File) {
-        _state.updateState { copy(lastFile = file) }
+    fun selectPath(path: Path) {
+        _state.updateState { copy(lastPath = path) }
     }
 
     fun reset() {
-        _state.updateState { copy(iconContent = null, lastFile = null) }
+        _state.updateState { copy(iconContent = null, lastPath = null) }
     }
 }

--- a/stability_config.conf
+++ b/stability_config.conf
@@ -1,2 +1,2 @@
 kotlin.collections.*
-java.io.File
+java.nio.file.Path


### PR DESCRIPTION
- Migrate file operations based on `Path`, with higher performance and scalability.
- Fallback to Path extensions in stdlib, we have no much necessary on `kotlinx-io-core`, there is no multiplatform need. This will also decrease the build artifact size.