### PR TITLE
Bump version to 0.3.2-SNAPSHOT

### DIFF
--- a/plugin.properties
+++ b/plugin.properties
@@ -1,2 +1,2 @@
 pluginName=Valkyrie
-version=0.3.1
+version=0.3.2-SNAPSHOT


### PR DESCRIPTION
We should always set the version to a snapshot after each release, it would be useful to be distinguished from market versions.