### PR TITLE
Add zipSigner dependency for intellijPlatform

### DIFF
--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     intellijPlatform {
         intellijIdeaCommunity("2024.1")
         instrumentationTools()
+        zipSigner()
     }
 }
 


### PR DESCRIPTION
Fixes error:

```
Execution failed for task ':idea-plugin:signPlugin'.
> No Marketplace ZIP Signer executable found.
  Please ensure the `zipSigner()` entry is present in the project dependencies section or `intellijPlatform.signing.cliPath` extension property
  See: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html#intellijPlatform-signing
```