### PR TITLE
Suppress ObjectPropertyName for generated backing fields

### DIFF
--- a/components/androidx-compose/src/main/kotlin/androidx/compose/material/icons/generator/Names.kt
+++ b/components/androidx-compose/src/main/kotlin/androidx/compose/material/icons/generator/Names.kt
@@ -48,6 +48,7 @@ object ClassNames {
     val Brush = PackageNames.GraphicsPackage.className("Brush")
     val Preview = PackageNames.PreviewPackage.className("Preview")
     val Composable = PackageNames.RuntimePackage.className("Composable")
+    val Suppress = ClassName.bestGuess("kotlin.Suppress")
 }
 
 /**

--- a/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/util/BackingPropertySpec.kt
+++ b/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/util/BackingPropertySpec.kt
@@ -1,5 +1,7 @@
 package io.github.composegears.valkyrie.generator.imagevector.util
 
+import androidx.compose.material.icons.generator.ClassNames
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeName
 import io.github.composegears.valkyrie.generator.ext.nullable
@@ -11,7 +13,12 @@ internal fun backingPropertySpec(
     name: String,
     type: TypeName,
 ) = propertySpecBuilder(name = name, type = type.nullable()) {
+    addAnnotation(suppressNamingAnnotation)
     mutable()
     addModifiers(KModifier.PRIVATE)
     initializer("null")
 }
+
+private val suppressNamingAnnotation = AnnotationSpec.builder(ClassNames.Suppress)
+    .addMember("%S", "ObjectPropertyName")
+    .build()

--- a/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/PreviewGenerationTest.kt
+++ b/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/PreviewGenerationTest.kt
@@ -32,6 +32,7 @@ class PreviewGenerationTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.tooling.preview.Preview
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val WithoutPath: ImageVector
                 get() {
@@ -49,6 +50,7 @@ class PreviewGenerationTest {
                     return _WithoutPath!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _WithoutPath: ImageVector? = null
 
             @Preview(showBackground = true)
@@ -89,6 +91,7 @@ class PreviewGenerationTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.tooling.preview.Preview
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val ValkyrieIcons.WithoutPath: ImageVector
                 get() {
@@ -106,6 +109,7 @@ class PreviewGenerationTest {
                     return _WithoutPath!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _WithoutPath: ImageVector? = null
 
             @Preview(showBackground = true)
@@ -147,6 +151,7 @@ class PreviewGenerationTest {
             import androidx.compose.ui.tooling.preview.Preview
             import androidx.compose.ui.unit.dp
             import io.github.composegears.valkyrie.icons.ValkyrieIcons
+            import kotlin.Suppress
 
             val ValkyrieIcons.Filled.WithoutPath: ImageVector
                 get() {
@@ -164,6 +169,7 @@ class PreviewGenerationTest {
                     return _WithoutPath!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _WithoutPath: ImageVector? = null
 
             @Preview(showBackground = true)

--- a/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/SvgGradientParserTest.kt
+++ b/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/SvgGradientParserTest.kt
@@ -31,6 +31,7 @@ class SvgGradientParserTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.graphics.vector.path
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val LinearGradient: ImageVector
                 get() {
@@ -199,6 +200,7 @@ class SvgGradientParserTest {
                     return _LinearGradient!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _LinearGradient: ImageVector? = null
 
         """.trimIndent()
@@ -229,6 +231,7 @@ class SvgGradientParserTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.graphics.vector.path
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val RadialGradient: ImageVector
                 get() {
@@ -265,6 +268,7 @@ class SvgGradientParserTest {
                     return _RadialGradient!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _RadialGradient: ImageVector? = null
 
         """.trimIndent()
@@ -296,6 +300,7 @@ class SvgGradientParserTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.graphics.vector.path
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val LinearGradientWithStroke: ImageVector
                 get() {
@@ -375,6 +380,7 @@ class SvgGradientParserTest {
                     return _LinearGradientWithStroke!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _LinearGradientWithStroke: ImageVector? = null
 
         """.trimIndent()

--- a/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/XmlParserTest.kt
+++ b/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/XmlParserTest.kt
@@ -26,6 +26,7 @@ class XmlParserTest {
 
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val WithoutPath: ImageVector
                 get() {
@@ -43,6 +44,7 @@ class XmlParserTest {
                     return _WithoutPath!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _WithoutPath: ImageVector? = null
 
         """.trimIndent()
@@ -70,6 +72,7 @@ class XmlParserTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.unit.dp
             import io.github.composegears.valkyrie.icons.ValkyrieIcons
+            import kotlin.Suppress
 
             val ValkyrieIcons.Colored.WithoutPath: ImageVector
                 get() {
@@ -87,6 +90,7 @@ class XmlParserTest {
                     return _WithoutPath!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _WithoutPath: ImageVector? = null
 
         """.trimIndent()
@@ -108,6 +112,7 @@ class XmlParserTest {
 
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val ValkyrieIcons.WithoutPath: ImageVector
                 get() {
@@ -125,6 +130,7 @@ class XmlParserTest {
                     return _WithoutPath!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _WithoutPath: ImageVector? = null
 
         """.trimIndent()
@@ -147,6 +153,7 @@ class XmlParserTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.graphics.vector.path
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val ValkyrieIcons.OnlyPath: ImageVector
                 get() {
@@ -175,6 +182,7 @@ class XmlParserTest {
                     return _OnlyPath!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _OnlyPath: ImageVector? = null
 
         """.trimIndent()
@@ -199,6 +207,7 @@ class XmlParserTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.graphics.vector.path
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val ValkyrieIcons.FillColorStroke: ImageVector
                 get() {
@@ -230,6 +239,7 @@ class XmlParserTest {
                     return _FillColorStroke!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _FillColorStroke: ImageVector? = null
 
         """.trimIndent()
@@ -248,7 +258,7 @@ class XmlParserTest {
 
         val expectedOutput = """
            package io.github.composegears.valkyrie.icons
-           
+
            import androidx.compose.ui.graphics.Color
            import androidx.compose.ui.graphics.PathFillType
            import androidx.compose.ui.graphics.SolidColor
@@ -257,6 +267,7 @@ class XmlParserTest {
            import androidx.compose.ui.graphics.vector.ImageVector
            import androidx.compose.ui.graphics.vector.path
            import androidx.compose.ui.unit.dp
+           import kotlin.Suppress
 
            val ValkyrieIcons.AllPathParams: ImageVector
                get() {
@@ -295,6 +306,7 @@ class XmlParserTest {
                    return _AllPathParams!!
                }
 
+           @Suppress("ObjectPropertyName")
            private var _AllPathParams: ImageVector? = null
 
         """.trimIndent()
@@ -319,6 +331,7 @@ class XmlParserTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.graphics.vector.path
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val ValkyrieIcons.SeveralPath: ImageVector
                 get() {
@@ -357,6 +370,7 @@ class XmlParserTest {
                     return _SeveralPath!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _SeveralPath: ImageVector? = null
 
         """.trimIndent()
@@ -382,6 +396,7 @@ class XmlParserTest {
             import androidx.compose.ui.graphics.vector.ImageVector
             import androidx.compose.ui.graphics.vector.path
             import androidx.compose.ui.unit.dp
+            import kotlin.Suppress
 
             val ValkyrieIcons.TransparentFillColor: ImageVector
                 get() {
@@ -424,6 +439,7 @@ class XmlParserTest {
                     return _TransparentFillColor!!
                 }
 
+            @Suppress("ObjectPropertyName")
             private var _TransparentFillColor: ImageVector? = null
 
         """.trimIndent()


### PR DESCRIPTION
`ObjectPropertyName` has now been honored by Detekt and Ktlint.