### PR TITLE
Enable build scan publishing on CI

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,20 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("com.gradle.develocity") version "3.17.6"
+}
+
+develocity {
+    buildScan {
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+        // TODO: workaround for https://github.com/gradle/gradle/issues/22879.
+        val isCI = providers.environmentVariable("CI").isPresent
+        publishing.onlyIf { isCI }
+    }
+}
+
 dependencyResolutionManagement {
     repositories {
         google {


### PR DESCRIPTION
Easier to view test reports and track deprecations.