### PR TITLE
Show plugin version in IntroScreen

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 - Multi edit icon pack
 - Simple mode without package
-- Add version into plugin settings
 - Optimize current icons (clean up, adding into pack)
 - Generate preview for whole icon pack
 - Add limitations for ImageVector

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/intro/IntroScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/intro/IntroScreen.kt
@@ -35,6 +35,7 @@ import io.github.composegears.valkyrie.ui.foundation.icons.BatchProcessing
 import io.github.composegears.valkyrie.ui.foundation.icons.SimpleConversion
 import io.github.composegears.valkyrie.ui.foundation.icons.ValkyrieIcons
 import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
+import io.github.composegears.valkyrie.ui.screen.intro.util.rememberPluginVersion
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.destination.IconPackDestinationScreen
 import io.github.composegears.valkyrie.ui.screen.mode.simple.setup.SimpleModeSetupScreen
 
@@ -99,6 +100,13 @@ private fun IntroScreenUI(onSelect: (Mode) -> Unit) {
                 description = "Create organized icon pack with batch export into your project",
             )
         }
+        Text(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 16.dp, bottom = 8.dp),
+            style = MaterialTheme.typography.labelSmall,
+            text = rememberPluginVersion(),
+        )
     }
 }
 

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/intro/util/PluginVersion.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/intro/util/PluginVersion.kt
@@ -1,0 +1,17 @@
+package io.github.composegears.valkyrie.ui.screen.intro.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalInspectionMode
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
+
+@Composable
+fun rememberPluginVersion(): String {
+    if (LocalInspectionMode.current) return "1.0.0"
+
+    return remember {
+        val pluginId = PluginId.getId("io.github.composegears.valkyrie")
+        PluginManagerCore.getPlugin(pluginId)?.version.toString()
+    }
+}


### PR DESCRIPTION
<img width="400" alt="Screenshot 2024-08-06 at 12 50 43" src="https://github.com/user-attachments/assets/0a4ed473-0214-46c8-bb4c-e0f24c5f0275">

For now only in Intro screen, later will be added into new settings 