### PR TITLE
Exclude kotlin-compiler-embeddable in distributions

### DIFF
--- a/components/psi/build.gradle.kts
+++ b/components/psi/build.gradle.kts
@@ -7,9 +7,10 @@ dependencies {
 
     // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
     compileOnly(libs.kotlin.stdlib)
+    // We don't have to include kotlin-compiler-embeddable in distributions.
+    compileOnly(libs.kotlin.embeddable)
 
-    implementation(libs.kotlin.embeddable)
-
+    testImplementation(libs.kotlin.embeddable)
     testImplementation(libs.bundles.test)
     testRuntimeOnly(libs.junit.launcher)
 }

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -31,14 +31,13 @@ dependencies {
     implementation(projects.components.parser)
     implementation(projects.components.psi)
 
-    // We don't have to include Compose deps into distributions.
     compileOnly(compose.desktop.currentOs)
-    compileOnly(compose.desktop.common)
-    compileOnly(compose.desktop.linux_arm64)
-    compileOnly(compose.desktop.linux_x64)
-    compileOnly(compose.desktop.macos_arm64)
-    compileOnly(compose.desktop.macos_x64)
-    compileOnly(compose.desktop.windows_x64)
+    implementation(compose.desktop.common)
+    implementation(compose.desktop.linux_arm64)
+    implementation(compose.desktop.linux_x64)
+    implementation(compose.desktop.macos_arm64)
+    implementation(compose.desktop.macos_x64)
+    implementation(compose.desktop.windows_x64)
     implementation(compose.material3)
 
     implementation(libs.android.build.tools)

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -31,13 +31,14 @@ dependencies {
     implementation(projects.components.parser)
     implementation(projects.components.psi)
 
+    // We don't have to include Compose deps into distributions.
     compileOnly(compose.desktop.currentOs)
-    implementation(compose.desktop.common)
-    implementation(compose.desktop.linux_arm64)
-    implementation(compose.desktop.linux_x64)
-    implementation(compose.desktop.macos_arm64)
-    implementation(compose.desktop.macos_x64)
-    implementation(compose.desktop.windows_x64)
+    compileOnly(compose.desktop.common)
+    compileOnly(compose.desktop.linux_arm64)
+    compileOnly(compose.desktop.linux_x64)
+    compileOnly(compose.desktop.macos_arm64)
+    compileOnly(compose.desktop.macos_x64)
+    compileOnly(compose.desktop.windows_x64)
     implementation(compose.material3)
 
     implementation(libs.android.build.tools)

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(projects.components.psi)
 
     compileOnly(compose.desktop.currentOs)
+    // These Compose Desktop deps include skiko-awt-runtime, they are still necessary for each OS.
     implementation(compose.desktop.common)
     implementation(compose.desktop.linux_arm64)
     implementation(compose.desktop.linux_x64)


### PR DESCRIPTION
```
 117.96 MB valkyrie-0.6.0-SNAPSHOT-after.zip
 184.73 MB valkyrie-0.6.0-SNAPSHOT-before.zip
```