### PR TITLE
UI adjustments, allow to navigate to IntroScreen from Conversion

### DIFF
--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/ValkyriePlugin.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/ValkyriePlugin.kt
@@ -56,6 +56,9 @@ fun ValkyriePlugin(
                 IconPack -> IconPackConversionScreen
                 Unspecified -> IntroScreen
             }
+            editBackStack {
+                add(IntroScreen)
+            }
             navigate(screen)
         },
     )

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/intro/IntroScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/intro/IntroScreen.kt
@@ -34,6 +34,7 @@ import io.github.composegears.valkyrie.ui.domain.model.Mode.Simple
 import io.github.composegears.valkyrie.ui.domain.model.Mode.Unspecified
 import io.github.composegears.valkyrie.ui.foundation.IconButton
 import io.github.composegears.valkyrie.ui.foundation.VerticalSpacer
+import io.github.composegears.valkyrie.ui.foundation.WeightSpacer
 import io.github.composegears.valkyrie.ui.foundation.icons.BatchProcessing
 import io.github.composegears.valkyrie.ui.foundation.icons.SimpleConversion
 import io.github.composegears.valkyrie.ui.foundation.icons.ValkyrieIcons
@@ -79,7 +80,7 @@ private fun IntroScreenUI(
     openSettings: () -> Unit,
     onModeChange: (Mode) -> Unit,
 ) {
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box {
         IconButton(
             modifier = Modifier
                 .padding(end = 8.dp)
@@ -90,35 +91,41 @@ private fun IntroScreenUI(
         Column(
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
         ) {
-            Text(
-                text = "Welcome to Valkyrie",
-                style = MaterialTheme.typography.titleLarge,
-                textAlign = TextAlign.Center,
-            )
-            VerticalSpacer(42.dp)
-            Text(
-                text = "Choose conversion mode",
-                style = MaterialTheme.typography.labelSmall,
-                color = LocalContentColor.current.copy(alpha = 0.5f),
-                textAlign = TextAlign.Center,
-            )
-            VerticalSpacer(8.dp)
+            WeightSpacer(weight = 0.3f)
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = "Welcome to Valkyrie",
+                    style = MaterialTheme.typography.titleLarge,
+                    textAlign = TextAlign.Center,
+                )
+                VerticalSpacer(42.dp)
+                Text(
+                    text = "Choose conversion mode",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = LocalContentColor.current.copy(alpha = 0.5f),
+                    textAlign = TextAlign.Center,
+                )
+                VerticalSpacer(8.dp)
 
-            SelectableCard(
-                onClick = { onModeChange(Simple) },
-                image = ValkyrieIcons.SimpleConversion,
-                title = "Simple",
-                description = "One-click conversion from SVG/XML into ImageVector",
-            )
-            VerticalSpacer(16.dp)
-            SelectableCard(
-                onClick = { onModeChange(IconPack) },
-                image = ValkyrieIcons.BatchProcessing,
-                title = "IconPack",
-                description = "Create organized icon pack with batch export into your project",
-            )
+                SelectableCard(
+                    onClick = { onModeChange(Simple) },
+                    image = ValkyrieIcons.SimpleConversion,
+                    title = "Simple",
+                    description = "One-click conversion from SVG/XML into ImageVector",
+                )
+                VerticalSpacer(16.dp)
+                SelectableCard(
+                    onClick = { onModeChange(IconPack) },
+                    image = ValkyrieIcons.BatchProcessing,
+                    title = "IconPack",
+                    description = "Create organized icon pack with batch export into your project",
+                )
+            }
+            WeightSpacer(weight = 0.7f)
         }
         Text(
             modifier = Modifier

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionScreen.kt
@@ -40,8 +40,11 @@ import com.composegears.tiamat.navDestination
 import com.composegears.tiamat.navigationSlideInOut
 import com.intellij.openapi.application.writeAction
 import com.intellij.openapi.vfs.VirtualFileManager
+import io.github.composegears.valkyrie.generator.imagevector.OutputFormat
 import io.github.composegears.valkyrie.settings.ValkyriesSettings
+import io.github.composegears.valkyrie.ui.domain.model.Mode
 import io.github.composegears.valkyrie.ui.foundation.AppBarTitle
+import io.github.composegears.valkyrie.ui.foundation.BackAction
 import io.github.composegears.valkyrie.ui.foundation.ClearAction
 import io.github.composegears.valkyrie.ui.foundation.SettingsAction
 import io.github.composegears.valkyrie.ui.foundation.TopAppBar
@@ -87,6 +90,9 @@ val IconPackConversionScreen by navDestination<Unit> {
     IconPackConversionUi(
         state = state,
         settings = settings,
+        onBack = {
+            navController.back(transition = navigationSlideInOut(false))
+        },
         openSettings = {
             navController.navigate(
                 dest = SettingsScreen,
@@ -107,6 +113,7 @@ val IconPackConversionScreen by navDestination<Unit> {
 private fun IconPackConversionUi(
     state: IconPackConversionState,
     settings: ValkyriesSettings,
+    onBack: () -> Unit,
     openSettings: () -> Unit,
     onPickEvent: (PickerEvent) -> Unit,
     updatePack: (BatchIcon, String) -> Unit,
@@ -143,6 +150,9 @@ private fun IconPackConversionUi(
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             TopAppBar {
+                if (state is IconsPickering) {
+                    BackAction(onBack = onBack)
+                }
                 if (state is BatchProcessing.IconPackCreationState) {
                     ClearAction(onClear = onReset)
                 }
@@ -222,6 +232,32 @@ private fun LoadingStateUi(message: String) {
             )
         }
     }
+}
+
+@Preview
+@Composable
+private fun IconPackConversionUiPickeringPreview() = PreviewTheme {
+    IconPackConversionUi(
+        state = IconsPickering,
+        settings = ValkyriesSettings(
+            mode = Mode.IconPack,
+            iconPackName = "MyPack",
+            packageName = "",
+            iconPackDestination = "",
+            nestedPacks = emptyList(),
+            outputFormat = OutputFormat.BackingProperty,
+            generatePreview = true,
+        ),
+        onBack = {},
+        openSettings = {},
+        onPickEvent = {},
+        updatePack = { _, _ -> },
+        onDeleteIcon = {},
+        onReset = {},
+        onPreviewClick = {},
+        onExport = {},
+        onRenameIcon = { _, _ -> },
+    )
 }
 
 @Preview

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/IconPackPickerStateUi.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/IconPackPickerStateUi.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.github.composegears.valkyrie.ui.foundation.DragAndDropBox
+import io.github.composegears.valkyrie.ui.foundation.WeightSpacer
 import io.github.composegears.valkyrie.ui.foundation.dashedBorder
 import io.github.composegears.valkyrie.ui.foundation.dnd.rememberMultiSelectDragAndDropHandler
 import io.github.composegears.valkyrie.ui.foundation.icons.Collections
@@ -52,10 +54,11 @@ fun IconPackPickerStateUi(
     val multipleFilePicker = rememberMultipleFilesPicker()
     val directoryPicker = rememberDirectoryPicker()
 
-    Box(
+    Column(
         modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        WeightSpacer(weight = 0.3f)
         SelectableState(
             onSelectPath = { paths ->
                 when {
@@ -89,6 +92,7 @@ fun IconPackPickerStateUi(
                 }
             },
         )
+        WeightSpacer(weight = 0.7f)
     }
 }
 

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/newpack/ui/foundation/ChoosePackDirectory.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/newpack/ui/foundation/ChoosePackDirectory.kt
@@ -113,6 +113,7 @@ fun ChoosePackDirectory(
                 }
             }
         }
+        VerticalSpacer(16.dp)
         Button(
             modifier = Modifier.align(Alignment.End),
             enabled = state.nextAvailable,

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/SimpleConversionScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/SimpleConversionScreen.kt
@@ -1,7 +1,6 @@
 package io.github.composegears.valkyrie.ui.screen.mode.simple.conversion
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -21,6 +20,7 @@ import com.composegears.tiamat.navDestination
 import com.composegears.tiamat.navigationSlideInOut
 import com.intellij.openapi.ide.CopyPasteManager
 import io.github.composegears.valkyrie.ui.foundation.AppBarTitle
+import io.github.composegears.valkyrie.ui.foundation.BackAction
 import io.github.composegears.valkyrie.ui.foundation.ClearAction
 import io.github.composegears.valkyrie.ui.foundation.CopyAction
 import io.github.composegears.valkyrie.ui.foundation.DragAndDropBox
@@ -49,6 +49,9 @@ val SimpleConversionScreen by navDestination<Unit> {
     ConversionUi(
         state = state,
         onSelectPath = viewModel::selectPath,
+        onBack = {
+            navController.back(transition = navigationSlideInOut(false))
+        },
         openSettings = {
             navController.navigate(
                 dest = SettingsScreen,
@@ -62,6 +65,7 @@ val SimpleConversionScreen by navDestination<Unit> {
 @Composable
 private fun ConversionUi(
     state: SimpleConversionState,
+    onBack: () -> Unit,
     onSelectPath: (Path) -> Unit,
     openSettings: () -> Unit,
     resetIconContent: () -> Unit,
@@ -72,6 +76,7 @@ private fun ConversionUi(
 
     PluginUI(
         content = state.iconContent,
+        onBack = onBack,
         onChoosePath = {
             scope.launch {
                 val path = filePicker.launch()
@@ -95,6 +100,7 @@ private fun ConversionUi(
 @Composable
 private fun PluginUI(
     content: String?,
+    onBack: () -> Unit,
     onChoosePath: () -> Unit,
     onClear: () -> Unit,
     onCopy: () -> Unit,
@@ -103,6 +109,7 @@ private fun PluginUI(
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar {
+            BackAction(onBack = onBack)
             AppBarTitle(title = "Simple conversion")
             WeightSpacer()
             if (content != null) {
@@ -118,14 +125,16 @@ private fun PluginUI(
                 text = content,
             )
         } else {
-            Box(
+            Column(
                 modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
+                WeightSpacer(weight = 0.3f)
                 SelectableState(
                     onSelectPath = onSelectPath,
                     onChoosePath = onChoosePath,
                 )
+                WeightSpacer(weight = 0.7f)
             }
         }
     }
@@ -169,5 +178,6 @@ private fun SimpleConversionScreenPreview() = PreviewTheme {
         onSelectPath = {},
         openSettings = {},
         resetIconContent = {},
+        onBack = {},
     )
 }


### PR DESCRIPTION
- More desktop friendly UI (suggested @vkatz)
- Allow to navigate back to Intro screen anytime from conversion screens