### PR TITLE
Handle camelCase icon names, introduce IconNameFormatter

### DIFF
--- a/components/parser/svgxml/src/main/kotlin/io/github/composegears/valkyrie/parser/svgxml/IconNameFormatter.kt
+++ b/components/parser/svgxml/src/main/kotlin/io/github/composegears/valkyrie/parser/svgxml/IconNameFormatter.kt
@@ -1,0 +1,22 @@
+package io.github.composegears.valkyrie.parser.svgxml
+
+import io.github.composegears.valkyrie.parser.svgxml.util.capitalized
+import io.github.composegears.valkyrie.parser.svgxml.util.removePrefix
+
+object IconNameFormatter {
+
+    private val invalidCharacterRegex = "[^a-zA-Z0-9\\-_ ]".toRegex()
+    private val camelCaseRegex = "(?<!^)(?=[A-Z])|(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)".toRegex()
+
+    fun format(name: String): String = name
+        .trimStart('-', '_')
+        .removeSuffix(".svg")
+        .removeSuffix(".xml")
+        .removePrefix("ic_")
+        .removePrefix("ic-")
+        .replace(invalidCharacterRegex, "_")
+        .split(camelCaseRegex)
+        .joinToString(separator = "") { it.capitalized() }
+        .split("_", "-")
+        .joinToString(separator = "") { it.capitalized() }
+}

--- a/components/parser/svgxml/src/main/kotlin/io/github/composegears/valkyrie/parser/svgxml/SvgXmlParser.kt
+++ b/components/parser/svgxml/src/main/kotlin/io/github/composegears/valkyrie/parser/svgxml/SvgXmlParser.kt
@@ -5,8 +5,6 @@ import io.github.composegears.valkyrie.parser.svgxml.svg.SvgToXmlParser
 import io.github.composegears.valkyrie.parser.svgxml.util.IconType
 import io.github.composegears.valkyrie.parser.svgxml.util.IconType.SVG
 import io.github.composegears.valkyrie.parser.svgxml.util.IconType.XML
-import io.github.composegears.valkyrie.parser.svgxml.util.capitalized
-import io.github.composegears.valkyrie.parser.svgxml.util.removePrefix
 import io.github.composegears.valkyrie.parser.svgxml.xml.XmlStringParser
 import java.nio.file.Path
 import kotlin.io.path.createTempFile
@@ -25,7 +23,7 @@ object SvgXmlParser {
     fun toIrImageVector(path: Path): IconParserOutput {
         val iconType = IconType.from(path.extension) ?: error("File not SVG or XML")
 
-        val fileName = getIconName(fileName = path.name)
+        val fileName = IconNameFormatter.format(name = path.name)
         val text = when (iconType) {
             SVG -> {
                 val tmpPath = createTempFile(suffix = "valkyrie/")
@@ -40,16 +38,4 @@ object SvgXmlParser {
             kotlinName = fileName,
         )
     }
-
-    // TODO: extract into separate class
-    fun getIconName(fileName: String) = fileName
-        .removePrefix("-")
-        .removePrefix("_")
-        .removeSuffix(".svg")
-        .removeSuffix(".xml")
-        .removePrefix("ic_")
-        .removePrefix("ic-")
-        .replace("[^a-zA-Z0-9\\-_ ]".toRegex(), "_")
-        .split("_", "-")
-        .joinToString(separator = "") { it.lowercase().capitalized() }
 }

--- a/components/parser/svgxml/src/test/kotlin/io/github/composegears/valkyrie/parser/svgxml/IconNameFormatterTest.kt
+++ b/components/parser/svgxml/src/test/kotlin/io/github/composegears/valkyrie/parser/svgxml/IconNameFormatterTest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import org.junit.jupiter.api.Test
 
-class XmlStringParserTest {
+class IconNameFormatterTest {
 
     private data class IconTest(
         val fileName: String,
@@ -12,8 +12,9 @@ class XmlStringParserTest {
     )
 
     @Test
-    fun `test icon name`() {
+    fun `check icon name formatting`() {
         val fileNames = listOf(
+            IconTest(fileName = "_ic_test_icon.svg", expected = "TestIcon"),
             IconTest(fileName = "ic_test_icon.svg", expected = "TestIcon"),
             IconTest(fileName = "ic_test_icon.xml", expected = "TestIcon"),
             IconTest(fileName = "test_icon.svg", expected = "TestIcon"),
@@ -21,12 +22,12 @@ class XmlStringParserTest {
             IconTest(fileName = "ic_test_icon_name.svg", expected = "TestIconName"),
             IconTest(fileName = "ic_testicon.svg", expected = "Testicon"),
             IconTest(fileName = "ic_test_icon_name_with_underscores.svg", expected = "TestIconNameWithUnderscores"),
-            IconTest(fileName = "ic_TESTIcon.svg", expected = "Testicon"),
+            IconTest(fileName = "ic_SVGIcon.svg", expected = "SVGIcon"),
             IconTest(fileName = "ic-test-icon.svg", expected = "TestIcon"),
             IconTest(fileName = "ic_test@icon!.svg", expected = "TestIcon"),
             IconTest(fileName = "ic_test_icon123.xml", expected = "TestIcon123"),
             IconTest(fileName = "my_icon.xml", expected = "MyIcon"),
-            IconTest(fileName = "Ic_TeSt123Icon.svg", expected = "Test123icon"),
+            IconTest(fileName = "Ic_TeSt123Icon.svg", expected = "TeSt123Icon"),
             IconTest(fileName = "ic_special@#\$%^&*()icon.svg", expected = "SpecialIcon"),
             IconTest(fileName = "ic--test__icon---name.svg", expected = "TestIconName"),
             IconTest(fileName = "@#$%.svg", expected = ""),
@@ -34,10 +35,14 @@ class XmlStringParserTest {
             IconTest(fileName = "-_ic_test_icon_-.svg", expected = "TestIcon"),
             IconTest(fileName = "pos_1", expected = "Pos1"),
             IconTest(fileName = "1", expected = "1"),
+            IconTest(fileName = "Ic_TempSvg123Icon.svg", expected = "TempSvg123Icon"),
+            IconTest(fileName = "fitContent", expected = "FitContent"),
+            IconTest(fileName = "fitContent_dark", expected = "FitContentDark"),
+            IconTest(fileName = "stub@20x20", expected = "Stub20X20"),
         )
 
         fileNames.forEach {
-            val iconName = SvgXmlParser.getIconName(it.fileName)
+            val iconName = IconNameFormatter.format(it.fileName)
 
             assertThat(iconName).isEqualTo(it.expected)
         }

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionViewModel.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionViewModel.kt
@@ -5,6 +5,7 @@ import io.github.composegears.valkyrie.extensions.cast
 import io.github.composegears.valkyrie.generator.imagevector.ImageVectorGenerator
 import io.github.composegears.valkyrie.generator.imagevector.ImageVectorGeneratorConfig
 import io.github.composegears.valkyrie.generator.imagevector.ImageVectorSpecOutput
+import io.github.composegears.valkyrie.parser.svgxml.IconNameFormatter
 import io.github.composegears.valkyrie.parser.svgxml.SvgXmlParser
 import io.github.composegears.valkyrie.parser.svgxml.util.isSvg
 import io.github.composegears.valkyrie.parser.svgxml.util.isXml
@@ -237,7 +238,7 @@ class IconPackConversionViewModel(
                                     extension = path.extension,
                                 )
                                 else -> BatchIcon.Valid(
-                                    iconName = IconName(SvgXmlParser.getIconName(path.name)),
+                                    iconName = IconName(IconNameFormatter.format(path.name)),
                                     extension = path.extension,
                                     iconPack = inMemorySettings.current.buildDefaultIconPack(),
                                     path = path,

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/BatchProcessingStateUi.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/BatchProcessingStateUi.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
-import io.github.composegears.valkyrie.parser.svgxml.SvgXmlParser
+import io.github.composegears.valkyrie.parser.svgxml.IconNameFormatter
 import io.github.composegears.valkyrie.ui.foundation.IconButton
 import io.github.composegears.valkyrie.ui.foundation.icons.ValkyrieIcons
 import io.github.composegears.valkyrie.ui.foundation.icons.Visibility
@@ -308,7 +308,7 @@ private fun BatchProcessingStatePreview() = PreviewTheme {
             exportEnabled = false,
             icons = listOf(
                 BatchIcon.Valid(
-                    iconName = IconName(SvgXmlParser.getIconName("ic_all_path_params_1")),
+                    iconName = IconName(IconNameFormatter.format("ic_all_path_params_1")),
                     extension = "xml",
                     path = Path(""),
                     iconPack = IconPack.Single(
@@ -321,7 +321,7 @@ private fun BatchProcessingStatePreview() = PreviewTheme {
                     extension = "svg",
                 ),
                 BatchIcon.Valid(
-                    iconName = IconName(SvgXmlParser.getIconName("ic_all_path")),
+                    iconName = IconName(IconNameFormatter.format("ic_all_path")),
                     extension = "svg",
                     path = Path(""),
                     iconPack = IconPack.Nested(


### PR DESCRIPTION
I found this issue when importing icons from https://intellij-icons.jetbrains.design/

<img width="532" alt="Screenshot 2024-09-01 at 19 47 27" src="https://github.com/user-attachments/assets/71ba6401-56e1-4873-a697-27a561039973">
