### PR TITLE
Revert gradle 8.10.1 to 8.10

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
task `runIde` failed to execute after gradle 8.10.1

<img width="1334" alt="Screenshot 2024-09-21 at 15 31 41" src="https://github.com/user-attachments/assets/7344abae-9d8a-47c6-bda9-49eabff0d107">
