### PR TITLE
Remove unnecessary kotlin.LazyThreadSafetyMode import from lazy property export format

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Outlined.Add: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
   ImageVector.Builder(

--- a/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/spec/LazyPropertySpec.kt
+++ b/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/spec/LazyPropertySpec.kt
@@ -54,7 +54,7 @@ internal class LazyPropertySpec(private val config: ImageVectorSpecConfig) {
 
         delegate(
             CodeBlock.builder()
-                .beginControlFlow("lazy(%T.NONE)", ClassNames.LazyThreadSafetyMode)
+                .beginControlFlow("lazy(LazyThreadSafetyMode.NONE)")
                 .add(codeBlock)
                 .endControlFlow()
                 .build(),

--- a/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/util/Names.kt
+++ b/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/util/Names.kt
@@ -30,7 +30,6 @@ internal object ClassNames {
     val Preview = PackageNames.PreviewPackage.className("Preview")
     val Composable = PackageNames.RuntimePackage.className("Composable")
     val Suppress = ClassName.bestGuess("kotlin.Suppress")
-    val LazyThreadSafetyMode = ClassName.bestGuess("kotlin.LazyThreadSafetyMode")
 }
 
 /**

--- a/components/generator/imagevector/src/test/resources/kt/lazy/AllPathParams.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/AllPathParams.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.AllPathParams: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/FillColorStroke.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/FillColorStroke.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.FillColorStroke: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/FlatPackage.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/FlatPackage.kt
@@ -2,7 +2,6 @@ package io.github.composegears.valkyrie.icons
 
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val FlatPackage: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/FlatPackage.pack.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/FlatPackage.pack.kt
@@ -2,7 +2,6 @@ package io.github.composegears.valkyrie.icons
 
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.FlatPackage: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/FlatPackage.pack.nested.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/FlatPackage.pack.nested.kt
@@ -2,7 +2,6 @@ package io.github.composegears.valkyrie.icons
 
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.Filled.FlatPackage: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/IconWithNamedArgs.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/IconWithNamedArgs.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.IconWithNamedArgs: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/IconWithShorthandColor.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/IconWithShorthandColor.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.group
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.IconWithShorthandColor: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/LinearGradient.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/LinearGradient.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val LinearGradient: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/LinearGradientWithStroke.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/LinearGradientWithStroke.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val LinearGradientWithStroke: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/OnlyPath.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/OnlyPath.kt
@@ -3,7 +3,6 @@ package io.github.composegears.valkyrie.icons
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.OnlyPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/RadialGradient.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/RadialGradient.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val RadialGradient: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/SeveralPath.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/SeveralPath.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.SeveralPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/TransparentFillColor.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/TransparentFillColor.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.TransparentFillColor: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.kt
@@ -2,7 +2,6 @@ package io.github.composegears.valkyrie.icons
 
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.pack.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.pack.kt
@@ -2,7 +2,6 @@ package io.github.composegears.valkyrie.icons
 
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.pack.nested.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.pack.nested.kt
@@ -3,7 +3,6 @@ package io.github.composegears.valkyrie.icons.colored
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.icons.ValkyrieIcons
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.Colored.WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.pack.nested.preview.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.pack.nested.preview.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.icons.ValkyrieIcons
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.Filled.WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.pack.preview.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.pack.preview.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val ValkyrieIcons.WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.preview.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.preview.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlin.LazyThreadSafetyMode
 
 val WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/colored/Videocam.kt
+++ b/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/colored/Videocam.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Colored.Videocam: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Add.kt
+++ b/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Add.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Outlined.Add: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Appearance.kt
+++ b/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Appearance.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Outlined.Appearance: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Arrow.kt
+++ b/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Arrow.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Outlined.Arrow: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/ArrowLeft.kt
+++ b/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/ArrowLeft.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Outlined.ArrowLeft: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/ArrowRight.kt
+++ b/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/ArrowRight.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Outlined.ArrowRight: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Brightness.kt
+++ b/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Brightness.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Outlined.Brightness: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Car.kt
+++ b/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Car.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Outlined.Car: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(

--- a/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Changelog.kt
+++ b/playground/app/src/main/kotlin/io/github/composegears/valkyrie/playground/icons/lazy/outlined/Changelog.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import io.github.composegears.valkyrie.playground.icons.lazy.LazyIcons
-import kotlin.LazyThreadSafetyMode
 
 val LazyIcons.Outlined.Changelog: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
     ImageVector.Builder(


### PR DESCRIPTION
- Fix: #198 