### PR TITLE
Disable ImageVector preview feature for "androidx.compose.material.icons" package

### DIFF
--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/editor/ImageVectorPreviewEditorProvider.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/editor/ImageVectorPreviewEditorProvider.kt
@@ -26,6 +26,10 @@ class ImageVectorPreviewEditorProvider :
             .bufferedReader()
             .use { it.readText() }
 
+        if (content.contains("package androidx.compose.material.icons\n")) {
+            return false
+        }
+
         return content.contains("androidx.compose.ui.graphics.vector.ImageVector") &&
             (
                 content.contains("androidx.compose.ui.graphics.vector.path") ||


### PR DESCRIPTION
- Close #203 

<img width="1512" alt="Screenshot 2024-10-03 at 14 20 18" src="https://github.com/user-attachments/assets/29e1bbff-742c-46e6-8903-47cff6345d67">
