### PR TITLE
feat: add indentation options for file export

### DIFF
--- a/components/generator/common/src/main/kotlin/io/github/composegears/valkyrie/generator/ext/Spec.kt
+++ b/components/generator/common/src/main/kotlin/io/github/composegears/valkyrie/generator/ext/Spec.kt
@@ -6,8 +6,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 
-private val Indent = " ".repeat(4)
-fun FileSpec.Builder.setIndent() = indent(Indent)
+fun FileSpec.Builder.setIndent(indent: Int) = indent(" ".repeat(indent))
 
 fun FileSpec.removeExplicitModeCode(): String = toString()
     .replace("public ", "")

--- a/components/generator/iconpack/src/main/kotlin/io/github/composegears/valkyrie/generator/iconpack/IconPackFileSpec.kt
+++ b/components/generator/iconpack/src/main/kotlin/io/github/composegears/valkyrie/generator/iconpack/IconPackFileSpec.kt
@@ -18,7 +18,7 @@ internal class IconPackFileSpec(private val config: IconPackGeneratorConfig) {
             fileName = config.iconPackName,
         ) {
             addType(iconPackSpec)
-            setIndent()
+            setIndent(config.indentSize)
         }
         return IconPackSpecOutput(
             content = when {

--- a/components/generator/iconpack/src/main/kotlin/io/github/composegears/valkyrie/generator/iconpack/IconPackGenerator.kt
+++ b/components/generator/iconpack/src/main/kotlin/io/github/composegears/valkyrie/generator/iconpack/IconPackGenerator.kt
@@ -5,6 +5,7 @@ data class IconPackGeneratorConfig(
     val iconPackName: String,
     val subPacks: List<String>,
     val useExplicitMode: Boolean,
+    val indentSize: Int,
 )
 
 data class IconPackSpecOutput(

--- a/components/generator/iconpack/src/test/kotlin/io/github/composegears/valkyrie/generator/iconpack/IcoPackWithIndentTest.kt
+++ b/components/generator/iconpack/src/test/kotlin/io/github/composegears/valkyrie/generator/iconpack/IcoPackWithIndentTest.kt
@@ -5,10 +5,10 @@ import assertk.assertions.isEqualTo
 import io.github.composegears.valkyrie.extensions.ResourceUtils.getResourceText
 import org.junit.jupiter.api.Test
 
-class IconPackGeneratorTest {
+class IcoPackWithIndentTest {
 
     private fun createConfig(
-        subPacks: List<String> = emptyList(),
+        subPacks: List<String> = listOf("Filled", "Colored"),
         useExplicitMode: Boolean = false,
         indentSize: Int = 4,
     ) = IconPackGeneratorConfig(
@@ -20,49 +20,36 @@ class IconPackGeneratorTest {
     )
 
     @Test
-    fun `generate icon pack`() {
-        val result = IconPackGenerator.create(config = createConfig())
-
-        val expected = getResourceText("kt/IconPack.kt")
-
-        assertThat(result.content).isEqualTo(expected)
-        assertThat(result.name).isEqualTo("ValkyrieIcons")
-    }
-
-    @Test
-    fun `generate icon pack explicit mode`() {
-        val result = IconPackGenerator.create(
-            config = createConfig(useExplicitMode = true),
-        )
-
-        val expected = getResourceText("kt/IconPack.explicit.kt")
+    fun `generate nested indent 1 packs`() {
+        val result = IconPackGenerator.create(config = createConfig(indentSize = 1))
+        val expected = getResourceText("kt/IconPack.nested.indent1.kt")
 
         assertThat(result.content).isEqualTo(expected)
         assertThat(result.name).isEqualTo("ValkyrieIcons")
     }
 
     @Test
-    fun `generate nested packs`() {
-        val result = IconPackGenerator.create(
-            config = createConfig(subPacks = listOf("Filled", "Colored")),
-        )
-
-        val expected = getResourceText("kt/IconPack.nested.kt")
+    fun `generate nested indent 2 packs`() {
+        val result = IconPackGenerator.create(config = createConfig(indentSize = 2))
+        val expected = getResourceText("kt/IconPack.nested.indent2.kt")
 
         assertThat(result.content).isEqualTo(expected)
         assertThat(result.name).isEqualTo("ValkyrieIcons")
     }
 
     @Test
-    fun `generate nested packs explicit`() {
-        val result = IconPackGenerator.create(
-            config = createConfig(
-                subPacks = listOf("Filled", "Colored"),
-                useExplicitMode = true,
-            ),
-        )
+    fun `generate nested indent 3 packs`() {
+        val result = IconPackGenerator.create(config = createConfig(indentSize = 3))
+        val expected = getResourceText("kt/IconPack.nested.indent3.kt")
 
-        val expected = getResourceText("kt/IconPack.nested.explicit.kt")
+        assertThat(result.content).isEqualTo(expected)
+        assertThat(result.name).isEqualTo("ValkyrieIcons")
+    }
+
+    @Test
+    fun `generate nested indent 6 packs`() {
+        val result = IconPackGenerator.create(config = createConfig(indentSize = 6))
+        val expected = getResourceText("kt/IconPack.nested.indent6.kt")
 
         assertThat(result.content).isEqualTo(expected)
         assertThat(result.name).isEqualTo("ValkyrieIcons")

--- a/components/generator/iconpack/src/test/resources/kt/IconPack.nested.indent1.kt
+++ b/components/generator/iconpack/src/test/resources/kt/IconPack.nested.indent1.kt
@@ -1,0 +1,7 @@
+package io.github.composegears.valkyrie.icons
+
+object ValkyrieIcons {
+ object Filled
+
+ object Colored
+}

--- a/components/generator/iconpack/src/test/resources/kt/IconPack.nested.indent2.kt
+++ b/components/generator/iconpack/src/test/resources/kt/IconPack.nested.indent2.kt
@@ -1,0 +1,7 @@
+package io.github.composegears.valkyrie.icons
+
+object ValkyrieIcons {
+  object Filled
+
+  object Colored
+}

--- a/components/generator/iconpack/src/test/resources/kt/IconPack.nested.indent3.kt
+++ b/components/generator/iconpack/src/test/resources/kt/IconPack.nested.indent3.kt
@@ -1,0 +1,7 @@
+package io.github.composegears.valkyrie.icons
+
+object ValkyrieIcons {
+   object Filled
+
+   object Colored
+}

--- a/components/generator/iconpack/src/test/resources/kt/IconPack.nested.indent6.kt
+++ b/components/generator/iconpack/src/test/resources/kt/IconPack.nested.indent6.kt
@@ -1,0 +1,7 @@
+package io.github.composegears.valkyrie.icons
+
+object ValkyrieIcons {
+      object Filled
+
+      object Colored
+}

--- a/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/ImageVectorFileSpec.kt
+++ b/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/ImageVectorFileSpec.kt
@@ -17,6 +17,7 @@ internal data class ImageVectorSpecConfig(
     val useFlatPackage: Boolean,
     val useExplicitMode: Boolean,
     val addTrailingComma: Boolean,
+    val indentSize: Int,
 )
 
 internal class ImageVectorFileSpec(private val config: ImageVectorSpecConfig) {

--- a/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/ImageVectorGenerator.kt
+++ b/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/ImageVectorGenerator.kt
@@ -12,6 +12,7 @@ data class ImageVectorGeneratorConfig(
     val useFlatPackage: Boolean,
     val useExplicitMode: Boolean,
     val addTrailingComma: Boolean,
+    val indentSize: Int,
 )
 
 enum class OutputFormat(val key: String) {
@@ -54,6 +55,7 @@ object ImageVectorGenerator {
             useFlatPackage = config.useFlatPackage,
             useExplicitMode = config.useExplicitMode,
             addTrailingComma = config.addTrailingComma,
+            indentSize = config.indentSize,
         ),
     ).createFileFor(vector)
 }

--- a/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/spec/BackingPropertySpec.kt
+++ b/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/spec/BackingPropertySpec.kt
@@ -44,7 +44,7 @@ internal class BackingPropertySpec(private val config: ImageVectorSpecConfig) {
                 iconPackClassName = iconPackClassName,
                 packageName = packageName,
             )
-            setIndent()
+            setIndent(config.indentSize)
         }
 
         return ImageVectorSpecOutput(

--- a/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/spec/LazyPropertySpec.kt
+++ b/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/spec/LazyPropertySpec.kt
@@ -34,7 +34,7 @@ internal class LazyPropertySpec(private val config: ImageVectorSpecConfig) {
                 iconPackClassName = iconPackClassName,
                 packageName = packageName,
             )
-            setIndent()
+            setIndent(config.indentSize)
         }
 
         return ImageVectorSpecOutput(

--- a/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/ImageVectorWithIndentTest.kt
+++ b/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/ImageVectorWithIndentTest.kt
@@ -1,0 +1,102 @@
+package io.github.composegears.valkyrie.generator.imagevector
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.github.composegears.valkyrie.extensions.ResourceUtils.getResourcePath
+import io.github.composegears.valkyrie.generator.imagevector.common.createConfig
+import io.github.composegears.valkyrie.generator.imagevector.common.toResourceText
+import io.github.composegears.valkyrie.parser.svgxml.SvgXmlParser
+import io.github.composegears.valkyrie.parser.svgxml.util.IconType.XML
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class ImageVectorWithIndentTest {
+
+    @ParameterizedTest
+    @EnumSource(value = OutputFormat::class)
+    fun `generation without icon pack with indent 1`(outputFormat: OutputFormat) {
+        val icon = getResourcePath("xml/ic_without_path.xml")
+        val parserOutput = SvgXmlParser.toIrImageVector(icon)
+        val output = ImageVectorGenerator.convert(
+            vector = parserOutput.irImageVector,
+            iconName = parserOutput.iconName,
+            config = createConfig(
+                outputFormat = outputFormat,
+                indentSize = 1,
+            ),
+        ).content
+
+        val expected = outputFormat.toResourceText(
+            pathToBackingProperty = "kt/backing/WithoutPath.indent1.kt",
+            pathToLazyProperty = "kt/lazy/WithoutPath.indent1.kt",
+        )
+        assertThat(parserOutput.iconType).isEqualTo(XML)
+        assertThat(output).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = OutputFormat::class)
+    fun `generation without icon pack with indent 2`(outputFormat: OutputFormat) {
+        val icon = getResourcePath("xml/ic_without_path.xml")
+        val parserOutput = SvgXmlParser.toIrImageVector(icon)
+        val output = ImageVectorGenerator.convert(
+            vector = parserOutput.irImageVector,
+            iconName = parserOutput.iconName,
+            config = createConfig(
+                outputFormat = outputFormat,
+                indentSize = 2,
+            ),
+        ).content
+
+        val expected = outputFormat.toResourceText(
+            pathToBackingProperty = "kt/backing/WithoutPath.indent2.kt",
+            pathToLazyProperty = "kt/lazy/WithoutPath.indent2.kt",
+        )
+        assertThat(parserOutput.iconType).isEqualTo(XML)
+        assertThat(output).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = OutputFormat::class)
+    fun `generation without icon pack with indent 3`(outputFormat: OutputFormat) {
+        val icon = getResourcePath("xml/ic_without_path.xml")
+        val parserOutput = SvgXmlParser.toIrImageVector(icon)
+        val output = ImageVectorGenerator.convert(
+            vector = parserOutput.irImageVector,
+            iconName = parserOutput.iconName,
+            config = createConfig(
+                outputFormat = outputFormat,
+                indentSize = 3,
+            ),
+        ).content
+
+        val expected = outputFormat.toResourceText(
+            pathToBackingProperty = "kt/backing/WithoutPath.indent3.kt",
+            pathToLazyProperty = "kt/lazy/WithoutPath.indent3.kt",
+        )
+        assertThat(parserOutput.iconType).isEqualTo(XML)
+        assertThat(output).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = OutputFormat::class)
+    fun `generation without icon pack with indent 6`(outputFormat: OutputFormat) {
+        val icon = getResourcePath("xml/ic_without_path.xml")
+        val parserOutput = SvgXmlParser.toIrImageVector(icon)
+        val output = ImageVectorGenerator.convert(
+            vector = parserOutput.irImageVector,
+            iconName = parserOutput.iconName,
+            config = createConfig(
+                outputFormat = outputFormat,
+                indentSize = 6,
+            ),
+        ).content
+
+        val expected = outputFormat.toResourceText(
+            pathToBackingProperty = "kt/backing/WithoutPath.indent6.kt",
+            pathToLazyProperty = "kt/lazy/WithoutPath.indent6.kt",
+        )
+        assertThat(parserOutput.iconType).isEqualTo(XML)
+        assertThat(output).isEqualTo(expected)
+    }
+}

--- a/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/common/TestImageVectorConfig.kt
+++ b/components/generator/imagevector/src/test/kotlin/io/github/composegears/valkyrie/generator/imagevector/common/TestImageVectorConfig.kt
@@ -13,6 +13,7 @@ internal fun createConfig(
     useFlatPackage: Boolean = false,
     useExplicitMode: Boolean = false,
     addTrailingComma: Boolean = false,
+    indentSize: Int = 4,
 ): ImageVectorGeneratorConfig {
     return ImageVectorGeneratorConfig(
         packageName = packageName,
@@ -24,5 +25,6 @@ internal fun createConfig(
         useFlatPackage = useFlatPackage,
         useExplicitMode = useExplicitMode,
         addTrailingComma = addTrailingComma,
+        indentSize = indentSize,
     )
 }

--- a/components/generator/imagevector/src/test/resources/kt/backing/WithoutPath.indent1.kt
+++ b/components/generator/imagevector/src/test/resources/kt/backing/WithoutPath.indent1.kt
@@ -1,0 +1,23 @@
+package io.github.composegears.valkyrie.icons
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+val WithoutPath: ImageVector
+ get() {
+  if (_WithoutPath != null) {
+   return _WithoutPath!!
+  }
+  _WithoutPath = ImageVector.Builder(
+   name = "WithoutPath",
+   defaultWidth = 24.dp,
+   defaultHeight = 24.dp,
+   viewportWidth = 18f,
+   viewportHeight = 18f
+  ).build()
+
+  return _WithoutPath!!
+ }
+
+@Suppress("ObjectPropertyName")
+private var _WithoutPath: ImageVector? = null

--- a/components/generator/imagevector/src/test/resources/kt/backing/WithoutPath.indent2.kt
+++ b/components/generator/imagevector/src/test/resources/kt/backing/WithoutPath.indent2.kt
@@ -1,0 +1,23 @@
+package io.github.composegears.valkyrie.icons
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+val WithoutPath: ImageVector
+  get() {
+    if (_WithoutPath != null) {
+      return _WithoutPath!!
+    }
+    _WithoutPath = ImageVector.Builder(
+      name = "WithoutPath",
+      defaultWidth = 24.dp,
+      defaultHeight = 24.dp,
+      viewportWidth = 18f,
+      viewportHeight = 18f
+    ).build()
+
+    return _WithoutPath!!
+  }
+
+@Suppress("ObjectPropertyName")
+private var _WithoutPath: ImageVector? = null

--- a/components/generator/imagevector/src/test/resources/kt/backing/WithoutPath.indent3.kt
+++ b/components/generator/imagevector/src/test/resources/kt/backing/WithoutPath.indent3.kt
@@ -1,0 +1,23 @@
+package io.github.composegears.valkyrie.icons
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+val WithoutPath: ImageVector
+   get() {
+      if (_WithoutPath != null) {
+         return _WithoutPath!!
+      }
+      _WithoutPath = ImageVector.Builder(
+         name = "WithoutPath",
+         defaultWidth = 24.dp,
+         defaultHeight = 24.dp,
+         viewportWidth = 18f,
+         viewportHeight = 18f
+      ).build()
+
+      return _WithoutPath!!
+   }
+
+@Suppress("ObjectPropertyName")
+private var _WithoutPath: ImageVector? = null

--- a/components/generator/imagevector/src/test/resources/kt/backing/WithoutPath.indent6.kt
+++ b/components/generator/imagevector/src/test/resources/kt/backing/WithoutPath.indent6.kt
@@ -1,0 +1,23 @@
+package io.github.composegears.valkyrie.icons
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+val WithoutPath: ImageVector
+      get() {
+            if (_WithoutPath != null) {
+                  return _WithoutPath!!
+            }
+            _WithoutPath = ImageVector.Builder(
+                  name = "WithoutPath",
+                  defaultWidth = 24.dp,
+                  defaultHeight = 24.dp,
+                  viewportWidth = 18f,
+                  viewportHeight = 18f
+            ).build()
+
+            return _WithoutPath!!
+      }
+
+@Suppress("ObjectPropertyName")
+private var _WithoutPath: ImageVector? = null

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.indent1.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.indent1.kt
@@ -1,0 +1,14 @@
+package io.github.composegears.valkyrie.icons
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+val WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
+ ImageVector.Builder(
+  name = "WithoutPath",
+  defaultWidth = 24.dp,
+  defaultHeight = 24.dp,
+  viewportWidth = 18f,
+  viewportHeight = 18f
+ ).build()
+}

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.indent2.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.indent2.kt
@@ -1,0 +1,14 @@
+package io.github.composegears.valkyrie.icons
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+val WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
+  ImageVector.Builder(
+    name = "WithoutPath",
+    defaultWidth = 24.dp,
+    defaultHeight = 24.dp,
+    viewportWidth = 18f,
+    viewportHeight = 18f
+  ).build()
+}

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.indent3.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.indent3.kt
@@ -1,0 +1,14 @@
+package io.github.composegears.valkyrie.icons
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+val WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
+   ImageVector.Builder(
+      name = "WithoutPath",
+      defaultWidth = 24.dp,
+      defaultHeight = 24.dp,
+      viewportWidth = 18f,
+      viewportHeight = 18f
+   ).build()
+}

--- a/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.indent6.kt
+++ b/components/generator/imagevector/src/test/resources/kt/lazy/WithoutPath.indent6.kt
@@ -1,0 +1,14 @@
+package io.github.composegears.valkyrie.icons
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+val WithoutPath: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
+      ImageVector.Builder(
+            name = "WithoutPath",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 18f,
+            viewportHeight = 18f
+      ).build()
+}

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/service/PersistentSettings.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/service/PersistentSettings.kt
@@ -43,6 +43,7 @@ class PersistentSettings : SimplePersistentStateComponent<ValkyrieState>(Valkyri
         var addTrailingComma: Boolean by property(false)
 
         var showImageVectorPreview: Boolean by property(true)
+        var indentSize: Int by property(4)
     }
 
     companion object {

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/settings/InMemorySettings.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/settings/InMemorySettings.kt
@@ -7,10 +7,12 @@ import io.github.composegears.valkyrie.service.PersistentSettings.Companion.pers
 import io.github.composegears.valkyrie.ui.domain.model.Mode
 import io.github.composegears.valkyrie.ui.extension.or
 import io.github.composegears.valkyrie.ui.extension.updateState
+import java.util.Collections.emptyList
+import java.util.Collections.emptyMap
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class InMemorySettings(project: Project) {
+class InMemorySettings(private val project: Project) {
     private val persistentSettings = project.persistentSettings
 
     init {
@@ -47,6 +49,7 @@ class InMemorySettings(project: Project) {
         useExplicitMode = false
         addTrailingComma = false
         showImageVectorPreview = true
+        indentSize = 4
     }
 
     fun updateUIState(uiState: Map<String, Any?>) {
@@ -72,7 +75,7 @@ class InMemorySettings(project: Project) {
             flatPackage = flatPackage,
             useExplicitMode = useExplicitMode,
             addTrailingComma = addTrailingComma,
-
+            indentSize = indentSize,
             showImageVectorPreview = showImageVectorPreview,
         )
     }
@@ -90,6 +93,7 @@ data class ValkyriesSettings(
     val nestedPacks: List<String>,
 
     val outputFormat: OutputFormat,
+    val indentSize: Int,
     val generatePreview: Boolean,
     val flatPackage: Boolean,
     val useExplicitMode: Boolean,

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/CenterRow.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/CenterRow.kt
@@ -1,0 +1,20 @@
+package io.github.composegears.valkyrie.ui.foundation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+inline fun CenterRow(
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
+    content: @Composable RowScope.() -> Unit,
+) = Row(
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = horizontalArrangement,
+    modifier = modifier,
+    content = content,
+)

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionViewModel.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionViewModel.kt
@@ -164,6 +164,7 @@ class IconPackConversionViewModel(
                         useFlatPackage = settings.flatPackage,
                         useExplicitMode = settings.useExplicitMode,
                         addTrailingComma = settings.addTrailingComma,
+                        indentSize = settings.indentSize,
                     ),
                 )
             }.getOrDefault(ImageVectorSpecOutput.empty)
@@ -202,6 +203,7 @@ class IconPackConversionViewModel(
                                     useFlatPackage = settings.flatPackage,
                                     useExplicitMode = settings.useExplicitMode,
                                     addTrailingComma = settings.addTrailingComma,
+                                    indentSize = settings.indentSize,
                                 ),
                             )
 
@@ -229,6 +231,7 @@ class IconPackConversionViewModel(
                                     useFlatPackage = settings.flatPackage,
                                     useExplicitMode = settings.useExplicitMode,
                                     addTrailingComma = settings.addTrailingComma,
+                                    indentSize = settings.indentSize,
                                 ),
                             )
 

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/creation/common/util/IconPackWriter.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/creation/common/util/IconPackWriter.kt
@@ -35,6 +35,7 @@ object IconPackWriter {
                     iconPackName = currentSettings.iconPackName,
                     subPacks = currentSettings.nestedPacks,
                     useExplicitMode = currentSettings.useExplicitMode,
+                    indentSize = currentSettings.indentSize,
                 ),
             )
             FileWriter.writeToFile(

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/existingpack/ui/viewmodel/ExistingPackViewModel.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/existingpack/ui/viewmodel/ExistingPackViewModel.kt
@@ -105,6 +105,7 @@ class ExistingPackViewModel : TiamatViewModel() {
                 iconPackName = inputFieldState.iconPackName.text,
                 subPacks = inputFieldState.nestedPacks.map { it.inputFieldState.text },
                 useExplicitMode = inMemorySettings.current.useExplicitMode,
+                indentSize = inMemorySettings.current.indentSize,
             ),
         ).content
 

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/newpack/ui/viewmodel/NewPackViewModel.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/newpack/ui/viewmodel/NewPackViewModel.kt
@@ -144,6 +144,7 @@ class NewPackViewModel : TiamatViewModel() {
                 iconPackName = inputFieldState.iconPackName.text,
                 subPacks = inputFieldState.nestedPacks.map { it.inputFieldState.text },
                 useExplicitMode = inMemorySettings.current.useExplicitMode,
+                indentSize = inMemorySettings.current.indentSize,
             ),
         ).content
         _events.emit(PreviewIconPackObject(code = iconPackCode))

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/viewmodel/SimpleConversionViewModel.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/simple/conversion/viewmodel/SimpleConversionViewModel.kt
@@ -172,6 +172,7 @@ class SimpleConversionViewModel(
                     useFlatPackage = false,
                     useExplicitMode = valkyriesSettings.useExplicitMode,
                     addTrailingComma = valkyriesSettings.addTrailingComma,
+                    indentSize = valkyriesSettings.indentSize,
                 ),
             )
             IconContent(
@@ -204,6 +205,7 @@ class SimpleConversionViewModel(
                     useFlatPackage = false,
                     useExplicitMode = valkyriesSettings.useExplicitMode,
                     addTrailingComma = valkyriesSettings.addTrailingComma,
+                    indentSize = valkyriesSettings.indentSize,
                 ),
             )
             IconContent(

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/SettingsViewModel.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.U
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateImageVectorPreview
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateOutputFormat
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdatePreviewGeneration
+import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateindentSize
 
 class SettingsViewModel : TiamatViewModel() {
 
@@ -27,6 +28,7 @@ class SettingsViewModel : TiamatViewModel() {
             is UpdateFlatPackage -> flatPackage = settingsAction.useFlatPackage
             is UpdateExplicitMode -> useExplicitMode = settingsAction.useExplicitMode
             is UpdateAddTrailingComma -> addTrailingComma = settingsAction.addTrailingComma
+            is UpdateindentSize -> indentSize = settingsAction.indent
         }
     }
 

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/model/SettingsAction.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/model/SettingsAction.kt
@@ -9,4 +9,5 @@ sealed interface SettingsAction {
     data class UpdateExplicitMode(val useExplicitMode: Boolean) : SettingsAction
     data class UpdateAddTrailingComma(val addTrailingComma: Boolean) : SettingsAction
     data class UpdateImageVectorPreview(val enabled: Boolean) : SettingsAction
+    data class UpdateindentSize(val indent: Int) : SettingsAction
 }

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/GeneralSettingsScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/GeneralSettingsScreen.kt
@@ -263,6 +263,7 @@ private fun GeneralSettingsPreview() = PreviewTheme(alignment = Alignment.TopSta
             showImageVectorPreview = true,
             addTrailingComma = true,
             useMaterialPack = false,
+            indentSize = 4,
         ),
         onChangeMode = {},
         onClearSettings = {},

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/ImageVectorExportSettingsScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/ImageVectorExportSettingsScreen.kt
@@ -33,6 +33,7 @@ import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.U
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateExplicitMode
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateFlatPackage
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdatePreviewGeneration
+import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateindentSize
 
 val ImageVectorExportSettingsScreen by navDestination<Unit> {
     val viewModel = rememberSharedViewModel(provider = ::SettingsViewModel)
@@ -44,6 +45,7 @@ val ImageVectorExportSettingsScreen by navDestination<Unit> {
         generatePreview = settings.generatePreview,
         useFlatPackage = settings.flatPackage,
         useExplicitMode = settings.useExplicitMode,
+        indentSize = settings.indentSize,
         addTrailingComma = settings.addTrailingComma,
     )
 }
@@ -55,6 +57,7 @@ private fun ImageVectorExportSettingsUi(
     useFlatPackage: Boolean,
     useExplicitMode: Boolean,
     addTrailingComma: Boolean,
+    indentSize: Int,
     onAction: (SettingsAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -92,6 +95,10 @@ private fun ImageVectorExportSettingsUi(
             description = "Note: Deprecated option, please consider to use build-in ImageVector preview feature",
             checked = generatePreview,
             onCheckedChange = { onAction(UpdatePreviewGeneration(it)) },
+        )
+        IndentSizeSection(
+            indent = indentSize,
+            onValueChange = { onAction(UpdateindentSize(it)) },
         )
         VerticalSpacer(16.dp)
     }
@@ -142,5 +149,6 @@ private fun ImageVectorExportSettingsPreview() = PreviewTheme(alignment = Alignm
         useFlatPackage = true,
         useExplicitMode = false,
         addTrailingComma = false,
+        indentSize = 4,
     )
 }

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/IndentSizeSection.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/IndentSizeSection.kt
@@ -1,0 +1,144 @@
+package io.github.composegears.valkyrie.ui.screen.settings.tabs.export
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.composegears.valkyrie.ui.foundation.CenterRow
+import io.github.composegears.valkyrie.ui.foundation.HorizontalSpacer
+import io.github.composegears.valkyrie.ui.foundation.dim
+import io.github.composegears.valkyrie.ui.foundation.rememberMutableState
+import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
+
+@Composable
+fun IndentSizeSection(
+    indent: Int,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by rememberMutableState { false }
+
+    val rotateAnimation by animateFloatAsState(
+        targetValue = when (expanded) {
+            true -> -180f
+            false -> 0f
+        },
+        animationSpec = tween(350),
+    )
+    ListItem(
+        modifier = modifier
+            .clickable { expanded = true }
+            .padding(horizontal = 8.dp),
+        headlineContent = {
+            Text(text = "Indent size")
+        },
+        supportingContent = {
+            Text(
+                text = "Determines the number of spaces used for each level of indentation in the exported icon",
+                style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                color = LocalContentColor.current.dim(),
+            )
+        },
+        trailingContent = {
+            CenterRow(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable { expanded = true }
+                    .padding(8.dp),
+            ) {
+                AnimatedIndentText(indent)
+                HorizontalSpacer(12.dp)
+                Icon(
+                    imageVector = Icons.Default.ArrowDropDown,
+                    contentDescription = null,
+                    modifier = Modifier.graphicsLayer {
+                        rotationZ = rotateAnimation
+                    },
+                )
+            }
+            IndentOptionMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                onClick = {
+                    onValueChange(it)
+                    expanded = false
+                },
+            )
+        },
+    )
+}
+
+@Composable
+private fun AnimatedIndentText(indent: Int) {
+    AnimatedContent(
+        targetState = indent,
+        transitionSpec = {
+            fadeIn() togetherWith fadeOut()
+        },
+    ) {
+        Text(
+            text = it.toString(),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@Composable
+private fun IndentOptionMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    onClick: (Int) -> Unit,
+) {
+    if (expanded) {
+        DropdownMenu(
+            expanded = true,
+            onDismissRequest = onDismissRequest,
+        ) {
+            repeat(10) {
+                val index = it + 1
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = index.toString(),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = LocalContentColor.current.dim(),
+                        )
+                    },
+                    onClick = { onClick(index) },
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun IndentSizeSectionPreview() = PreviewTheme {
+    IndentSizeSection(
+        indent = 4,
+        onValueChange = { },
+    )
+}


### PR DESCRIPTION
This option will by default read the `indent_size` option from the `.editorconfig` file in the project; if not found, it will use the default of 4 spaces for indentation