### PR TITLE
[IconPack mode] Add Scrollbar

### DIFF
--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/Scrollbar.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/Scrollbar.kt
@@ -1,0 +1,55 @@
+package io.github.composegears.valkyrie.ui.foundation
+
+import androidx.compose.foundation.HorizontalScrollbar
+import androidx.compose.foundation.LocalScrollbarStyle
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.v2.ScrollbarAdapter
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BoxScope.VerticalScrollbar(
+    adapter: ScrollbarAdapter,
+    modifier: Modifier = Modifier,
+) {
+    val scrollbarStyle = LocalScrollbarStyle.current.copy(
+        unhoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+        hoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+    )
+
+    VerticalScrollbar(
+        modifier = modifier
+            .fillMaxHeight()
+            .align(Alignment.CenterEnd)
+            .padding(end = 4.dp, top = 8.dp, bottom = 4.dp),
+        adapter = adapter,
+        style = scrollbarStyle,
+    )
+}
+
+@Composable
+fun BoxScope.HorizontalScrollbar(
+    adapter: ScrollbarAdapter,
+    modifier: Modifier = Modifier,
+) {
+    val scrollbarStyle = LocalScrollbarStyle.current.copy(
+        unhoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+        hoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+    )
+
+    HorizontalScrollbar(
+        modifier = modifier
+            .fillMaxWidth()
+            .align(Alignment.BottomStart)
+            .padding(start = 8.dp, end = 20.dp, bottom = 4.dp),
+        adapter = adapter,
+        style = scrollbarStyle,
+    )
+}

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/highlights/core/CodeEditor.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/highlights/core/CodeEditor.kt
@@ -1,15 +1,11 @@
 package io.github.composegears.valkyrie.ui.foundation.highlights.core
 
-import androidx.compose.foundation.HorizontalScrollbar
-import androidx.compose.foundation.LocalScrollbarStyle
-import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -19,7 +15,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
@@ -29,7 +24,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextRange
@@ -41,6 +35,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.snipme.highlights.Highlights
+import io.github.composegears.valkyrie.ui.foundation.HorizontalScrollbar
+import io.github.composegears.valkyrie.ui.foundation.VerticalScrollbar
 import io.github.composegears.valkyrie.ui.foundation.disabled
 import io.github.composegears.valkyrie.ui.foundation.rememberMutableIntState
 import io.github.composegears.valkyrie.ui.foundation.rememberMutableState
@@ -82,11 +78,6 @@ fun CodeEditor(
     LaunchedEffect(verticalScrollState.value) {
         linesTextScroll.scrollTo(verticalScrollState.value)
     }
-
-    val scrollbarStyle = LocalScrollbarStyle.current.copy(
-        unhoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
-        hoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-    )
 
     Box(modifier = modifier) {
         Row(modifier = Modifier.fillMaxSize()) {
@@ -149,22 +140,8 @@ fun CodeEditor(
                     colors = colors,
                 )
 
-                VerticalScrollbar(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .align(Alignment.CenterEnd)
-                        .padding(end = 4.dp, top = 8.dp, bottom = 16.dp),
-                    adapter = rememberScrollbarAdapter(verticalScrollState),
-                    style = scrollbarStyle,
-                )
-                HorizontalScrollbar(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 8.dp, bottom = 4.dp, end = 16.dp)
-                        .align(Alignment.BottomCenter),
-                    adapter = rememberScrollbarAdapter(horizontalScrollState),
-                    style = scrollbarStyle,
-                )
+                VerticalScrollbar(adapter = rememberScrollbarAdapter(verticalScrollState))
+                HorizontalScrollbar(adapter = rememberScrollbarAdapter(horizontalScrollState))
             }
         }
     }

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionScreen.kt
@@ -58,8 +58,8 @@ import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconPa
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconPackConversionState.BatchProcessing.IconPackCreationState
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconPackConversionState.BatchProcessing.ImportValidationState
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconPackConversionState.IconsPickering
-import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.BatchProcessingStateUi
-import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.IconPackPickerStateUi
+import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.BatchProcessingStateUi
+import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.picker.IconPackPickerStateUi
 import io.github.composegears.valkyrie.ui.screen.preview.CodePreviewScreen
 import io.github.composegears.valkyrie.ui.screen.settings.SettingsScreen
 import kotlinx.coroutines.flow.launchIn

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/BatchProcessingStateUi.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/BatchProcessingStateUi.kt
@@ -1,4 +1,4 @@
-package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui
+package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.desktop.ui.tooling.preview.Preview
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -39,6 +41,7 @@ import io.github.composegears.valkyrie.parser.svgxml.IconNameFormatter
 import io.github.composegears.valkyrie.parser.svgxml.util.IconType.SVG
 import io.github.composegears.valkyrie.parser.svgxml.util.IconType.XML
 import io.github.composegears.valkyrie.ui.foundation.IconButton
+import io.github.composegears.valkyrie.ui.foundation.VerticalScrollbar
 import io.github.composegears.valkyrie.ui.foundation.icons.ValkyrieIcons
 import io.github.composegears.valkyrie.ui.foundation.icons.Visibility
 import io.github.composegears.valkyrie.ui.foundation.rememberMutableState
@@ -47,9 +50,9 @@ import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.BatchI
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconName
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconPack
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconPackConversionState.BatchProcessing.IconPackCreationState
-import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.FileTypeBadge
-import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.IconNameField
-import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.IconPreviewBox
+import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.ui.FileTypeBadge
+import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.ui.IconNameField
+import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.ui.IconPreviewBox
 
 @Composable
 fun BatchProcessingStateUi(
@@ -60,30 +63,34 @@ fun BatchProcessingStateUi(
     onRenameIcon: (BatchIcon, IconName) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyVerticalGrid(
-        modifier = modifier.fillMaxSize(),
-        columns = GridCells.Adaptive(300.dp),
-        contentPadding = PaddingValues(16.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        items(items = state.icons, key = { it.iconName }) { batchIcon ->
-            when (batchIcon) {
-                is BatchIcon.Broken -> BrokenIconItem(
-                    modifier = Modifier.animateItem(),
-                    broken = batchIcon,
-                    onDelete = onDeleteIcon,
-                )
-                is BatchIcon.Valid -> ValidIconItem(
-                    modifier = Modifier.animateItem(),
-                    icon = batchIcon,
-                    onUpdatePack = onUpdatePack,
-                    onDeleteIcon = onDeleteIcon,
-                    onPreview = onPreviewClick,
-                    onRenameIcon = onRenameIcon,
-                )
+    Box(modifier = modifier) {
+        val lazyGridState = rememberLazyGridState()
+
+        LazyVerticalGrid(
+            state = lazyGridState,
+            modifier = Modifier.fillMaxSize(),
+            columns = GridCells.Adaptive(300.dp),
+            contentPadding = PaddingValues(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(items = state.icons, key = { it.iconName }) { batchIcon ->
+                when (batchIcon) {
+                    is BatchIcon.Broken -> BrokenIconItem(
+                        broken = batchIcon,
+                        onDelete = onDeleteIcon,
+                    )
+                    is BatchIcon.Valid -> ValidIconItem(
+                        icon = batchIcon,
+                        onUpdatePack = onUpdatePack,
+                        onDeleteIcon = onDeleteIcon,
+                        onPreview = onPreviewClick,
+                        onRenameIcon = onRenameIcon,
+                    )
+                }
             }
         }
+        VerticalScrollbar(adapter = rememberScrollbarAdapter(lazyGridState))
     }
 }
 

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/ui/FileTypeBadge.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/ui/FileTypeBadge.kt
@@ -1,4 +1,4 @@
-package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch
+package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/ui/IconNameField.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/ui/IconNameField.kt
@@ -1,4 +1,4 @@
-package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch
+package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.ui
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.LocalIndication

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/ui/IconPreviewBox.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/batch/ui/IconPreviewBox.kt
@@ -1,4 +1,4 @@
-package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch
+package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.batch.ui
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.Image

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/picker/IconPackPickerStateUi.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/ui/picker/IconPackPickerStateUi.kt
@@ -1,4 +1,4 @@
-package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui
+package io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ui.picker
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.desktop.ui.tooling.preview.Preview


### PR DESCRIPTION
Removed `Modifier.animateItem()` due to crash 
https://youtrack.jetbrains.com/issue/CMP-1980/Clicking-on-scrollbar-area-before-its-shown-crashes-with-Cannot-round-NaN-value


https://github.com/user-attachments/assets/5ba6d2d2-5b21-48eb-ab51-bd9e09eb7a2a

