### PR TITLE
Use Monospace font for CodeViewer and CodeEditor

### DIFF
--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/highlights/KotlinCodeViewer.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/highlights/KotlinCodeViewer.kt
@@ -42,7 +42,7 @@ fun KotlinCodeViewer(
 
             onChange(it)
         },
-        textStyle = MaterialTheme.typography.bodyMedium.copy(lineHeight = 21.sp),
+        textStyle = MaterialTheme.typography.bodyMedium.copy(lineHeight = 21.sp, fontSize = 13.sp),
         colors = TextFieldDefaults.colors(
             unfocusedContainerColor = Color.Transparent,
             focusedContainerColor = Color.Transparent,

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/highlights/core/CodeEditor.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/highlights/core/CodeEditor.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
@@ -123,7 +124,7 @@ fun CodeEditor(
                     ),
                     enabled = enabled,
                     readOnly = readOnly,
-                    textStyle = textStyle,
+                    textStyle = textStyle.copy(fontFamily = FontFamily.Monospace),
                     label = label,
                     placeholder = placeholder,
                     leadingIcon = leadingIcon,

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/highlights/core/CodeViewer.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/foundation/highlights/core/CodeViewer.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
 import dev.snipme.highlights.Highlights
 import dev.snipme.highlights.model.PhraseLocation
 import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
@@ -16,7 +17,7 @@ fun CodeViewer(
 ) {
     Text(
         modifier = modifier,
-        style = MaterialTheme.typography.bodySmall,
+        style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
         text = highlights.buildAnnotatedString(),
     )
 }


### PR DESCRIPTION
- closes #292 

<img width="1292" alt="Screenshot 2024-11-15 at 11 39 32" src="https://github.com/user-attachments/assets/7ba47654-212b-4049-95fc-4e74a06ce393">
