### PR TITLE
Override project name to avoid conflict with "Compose Multiplatform plugin"

### DIFF
--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -46,6 +46,7 @@ compose.resources {
 
 intellijPlatform {
     buildSearchableOptions = false
+    projectName = "valkyrie-plugin"
     pluginConfiguration.ideaVersion {
         sinceBuild = "241"
         untilBuild = provider { null }


### PR DESCRIPTION
- closes #361 

Support issue: https://platform.jetbrains.com/t/impossible-to-install-both-valkyrie-plugin-and-compose-multiplatform-ide-support-plugin/731


before
<img width="271" alt="Screenshot 2025-02-28 at 22 55 16" src="https://github.com/user-attachments/assets/6799955d-4312-4e07-8a4a-97976689a58e" />

after

<img width="327" alt="Screenshot 2025-02-28 at 22 56 28" src="https://github.com/user-attachments/assets/c92ddb4f-ba10-4615-af3a-8b0e468fee82" />
