### PR TITLE
Introduce separate Preview annotation for AndroidX and Jetbrains package

### DIFF
--- a/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/ImageVectorGenerator.kt
+++ b/components/generator/imagevector/src/main/kotlin/io/github/composegears/valkyrie/generator/imagevector/ImageVectorGenerator.kt
@@ -15,6 +15,16 @@ data class ImageVectorGeneratorConfig(
     val indentSize: Int,
 )
 
+enum class PreviewAnnotationType(val key: String) {
+    AndroidX("androidx"),
+    Jetbrains("jetbrains"),
+    ;
+
+    companion object {
+        fun from(key: String?) = PreviewAnnotationType.entries.find { it.key == key } ?: AndroidX
+    }
+}
+
 enum class OutputFormat(val key: String) {
     BackingProperty(key = "backing_property"),
     LazyProperty(key = "lazy_property"),

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/service/PersistentSettings.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/service/PersistentSettings.kt
@@ -39,6 +39,8 @@ class PersistentSettings : SimplePersistentStateComponent<ValkyrieState>(Valkyri
         var nestedPacks: String? by string()
 
         var generatePreview: Boolean by property(false)
+        var previewAnnotationType by string()
+
         var outputFormat: String? by string()
         var flatPackage: Boolean by property(false)
         var useExplicitMode: Boolean by property(false)

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/settings/InMemorySettings.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/settings/InMemorySettings.kt
@@ -2,6 +2,7 @@ package io.github.composegears.valkyrie.settings
 
 import com.intellij.openapi.project.Project
 import io.github.composegears.valkyrie.generator.imagevector.OutputFormat
+import io.github.composegears.valkyrie.generator.imagevector.PreviewAnnotationType
 import io.github.composegears.valkyrie.service.PersistentSettings
 import io.github.composegears.valkyrie.service.PersistentSettings.Companion.persistentSettings
 import io.github.composegears.valkyrie.ui.domain.model.Mode
@@ -47,6 +48,7 @@ class InMemorySettings(project: Project) {
         updateNestedPack(packs = emptyList())
         updateOutputFormat(OutputFormat.BackingProperty)
         generatePreview = false
+        updatePreviewAnnotationType(PreviewAnnotationType.AndroidX)
         flatPackage = false
         useExplicitMode = false
         addTrailingComma = false
@@ -74,7 +76,10 @@ class InMemorySettings(project: Project) {
                 .filter { it.isNotEmpty() },
 
             outputFormat = OutputFormat.from(outputFormat),
+
             generatePreview = generatePreview,
+            previewAnnotationType = PreviewAnnotationType.from(previewAnnotationType),
+
             flatPackage = flatPackage,
             useExplicitMode = useExplicitMode,
             addTrailingComma = addTrailingComma,
@@ -96,9 +101,11 @@ data class ValkyriesSettings(
 
     val nestedPacks: List<String>,
 
+    val generatePreview: Boolean,
+    val previewAnnotationType: PreviewAnnotationType,
+
     val outputFormat: OutputFormat,
     val indentSize: Int,
-    val generatePreview: Boolean,
     val flatPackage: Boolean,
     val useExplicitMode: Boolean,
     val addTrailingComma: Boolean,
@@ -115,4 +122,8 @@ fun PersistentSettings.ValkyrieState.updateNestedPack(packs: List<String>) {
 
 fun PersistentSettings.ValkyrieState.updateOutputFormat(format: OutputFormat) {
     outputFormat = format.key
+}
+
+fun PersistentSettings.ValkyrieState.updatePreviewAnnotationType(type: PreviewAnnotationType) {
+    previewAnnotationType = type.key
 }

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/SettingsViewModel.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/SettingsViewModel.kt
@@ -1,9 +1,15 @@
 package io.github.composegears.valkyrie.ui.screen.settings
 
 import com.composegears.tiamat.TiamatViewModel
+import com.intellij.collaboration.async.mapState
+import io.github.composegears.valkyrie.generator.imagevector.OutputFormat
+import io.github.composegears.valkyrie.generator.imagevector.PreviewAnnotationType
 import io.github.composegears.valkyrie.settings.updateOutputFormat
+import io.github.composegears.valkyrie.settings.updatePreviewAnnotationType
 import io.github.composegears.valkyrie.ui.di.DI
+import io.github.composegears.valkyrie.ui.domain.model.Mode
 import io.github.composegears.valkyrie.ui.domain.model.Mode.Unspecified
+import io.github.composegears.valkyrie.ui.domain.model.PreviewType
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateAddTrailingComma
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateExplicitMode
@@ -11,13 +17,40 @@ import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.U
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateImageVectorPreview
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateIndentSize
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateOutputFormat
+import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdatePreviewAnnotationType
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdatePreviewGeneration
 
+@Suppress("UnstableApiUsage")
 class SettingsViewModel : TiamatViewModel() {
 
     private val inMemorySettings by DI.core.inMemorySettings
 
-    val settings = inMemorySettings.settings
+    val exportSettings = inMemorySettings.settings.mapState {
+        ExportSettings(
+            outputFormat = it.outputFormat,
+            generatePreview = it.generatePreview,
+            useFlatPackage = it.flatPackage,
+            useExplicitMode = it.useExplicitMode,
+            addTrailingComma = it.addTrailingComma,
+            indentSize = it.indentSize,
+            previewAnnotationType = it.previewAnnotationType,
+        )
+    }
+
+    val generalSettings = inMemorySettings.settings.mapState {
+        GeneralSettings(
+            mode = it.mode,
+            packageName = it.packageName,
+            iconPackDestination = it.iconPackDestination,
+        )
+    }
+
+    val previewSettings = inMemorySettings.settings.mapState {
+        PreviewSettings(
+            previewType = it.previewType,
+            showImageVectorPreview = it.showImageVectorPreview,
+        )
+    }
 
     fun onAction(settingsAction: SettingsAction) = inMemorySettings.update {
         when (settingsAction) {
@@ -29,6 +62,7 @@ class SettingsViewModel : TiamatViewModel() {
             is UpdateAddTrailingComma -> addTrailingComma = settingsAction.addTrailingComma
             is UpdateIndentSize -> indentSize = settingsAction.indent
             is SettingsAction.UpdatePreviewType -> previewType = settingsAction.previewType
+            is UpdatePreviewAnnotationType -> updatePreviewAnnotationType(settingsAction.annotationType)
         }
     }
 
@@ -38,3 +72,24 @@ class SettingsViewModel : TiamatViewModel() {
         mode = Unspecified
     }
 }
+
+data class ExportSettings(
+    val outputFormat: OutputFormat,
+    val useFlatPackage: Boolean,
+    val useExplicitMode: Boolean,
+    val addTrailingComma: Boolean,
+    val indentSize: Int,
+    val generatePreview: Boolean,
+    val previewAnnotationType: PreviewAnnotationType,
+)
+
+data class GeneralSettings(
+    val mode: Mode,
+    val packageName: String,
+    val iconPackDestination: String,
+)
+
+data class PreviewSettings(
+    val showImageVectorPreview: Boolean,
+    val previewType: PreviewType,
+)

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/model/SettingsAction.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/model/SettingsAction.kt
@@ -1,15 +1,18 @@
 package io.github.composegears.valkyrie.ui.screen.settings.model
 
 import io.github.composegears.valkyrie.generator.imagevector.OutputFormat
+import io.github.composegears.valkyrie.generator.imagevector.PreviewAnnotationType
 import io.github.composegears.valkyrie.ui.domain.model.PreviewType
 
 sealed interface SettingsAction {
     data class UpdateOutputFormat(val outputFormat: OutputFormat) : SettingsAction
-    data class UpdatePreviewGeneration(val generate: Boolean) : SettingsAction
     data class UpdateFlatPackage(val useFlatPackage: Boolean) : SettingsAction
     data class UpdateExplicitMode(val useExplicitMode: Boolean) : SettingsAction
     data class UpdateAddTrailingComma(val addTrailingComma: Boolean) : SettingsAction
-    data class UpdateImageVectorPreview(val enabled: Boolean) : SettingsAction
+    data class UpdatePreviewGeneration(val generate: Boolean) : SettingsAction
+    data class UpdatePreviewAnnotationType(val annotationType: PreviewAnnotationType) : SettingsAction
     data class UpdateIndentSize(val indent: Int) : SettingsAction
+
+    data class UpdateImageVectorPreview(val enabled: Boolean) : SettingsAction
     data class UpdatePreviewType(val previewType: PreviewType) : SettingsAction
 }

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/GeneralSettingsScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/GeneralSettingsScreen.kt
@@ -34,12 +34,9 @@ import com.composegears.tiamat.NavController
 import com.composegears.tiamat.navController
 import com.composegears.tiamat.navDestination
 import com.composegears.tiamat.rememberSharedViewModel
-import io.github.composegears.valkyrie.generator.imagevector.OutputFormat
-import io.github.composegears.valkyrie.settings.ValkyriesSettings
 import io.github.composegears.valkyrie.ui.domain.model.Mode.IconPack
 import io.github.composegears.valkyrie.ui.domain.model.Mode.Simple
 import io.github.composegears.valkyrie.ui.domain.model.Mode.Unspecified
-import io.github.composegears.valkyrie.ui.domain.model.PreviewType
 import io.github.composegears.valkyrie.ui.foundation.CenterVerticalRow
 import io.github.composegears.valkyrie.ui.foundation.InfoItem
 import io.github.composegears.valkyrie.ui.foundation.VerticalSpacer
@@ -52,18 +49,19 @@ import io.github.composegears.valkyrie.ui.foundation.rememberMutableState
 import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
 import io.github.composegears.valkyrie.ui.platform.rememberCurrentProject
 import io.github.composegears.valkyrie.ui.screen.intro.IntroScreen
+import io.github.composegears.valkyrie.ui.screen.settings.GeneralSettings
 import io.github.composegears.valkyrie.ui.screen.settings.SettingsViewModel
 
 val GeneralSettingsScreen by navDestination<Unit> {
     val navController = navController()
 
     val viewModel = rememberSharedViewModel(provider = ::SettingsViewModel)
-    val settings by viewModel.settings.collectAsState()
+    val generalSettings by viewModel.generalSettings.collectAsState()
 
     var showClearSettingsDialog by rememberMutableState { false }
 
     GeneralSettingsUi(
-        settings = settings,
+        generalSettings = generalSettings,
         onClearSettings = {
             showClearSettingsDialog = true
         },
@@ -95,12 +93,12 @@ private fun openIntro(navController: NavController) {
 
 @Composable
 private fun GeneralSettingsUi(
-    settings: ValkyriesSettings,
+    generalSettings: GeneralSettings,
     onClearSettings: () -> Unit,
     modifier: Modifier = Modifier,
     onChangeMode: () -> Unit,
 ) {
-    val mode = settings.mode
+    val mode = generalSettings.mode
     val initialMode = remember { mode }
     val currentMode = remember(mode) {
         when (mode) {
@@ -169,15 +167,15 @@ private fun GeneralSettingsUi(
             modifier = Modifier.padding(horizontal = 24.dp),
             title = "Export path",
             description = when {
-                settings.iconPackDestination.isEmpty() -> "Not specified"
-                else -> "~${settings.iconPackDestination.replace(currentProject.path.orEmpty(), "")}"
+                generalSettings.iconPackDestination.isEmpty() -> "Not specified"
+                else -> "~${generalSettings.iconPackDestination.replace(currentProject.path.orEmpty(), "")}"
             },
         )
         VerticalSpacer(16.dp)
         InfoItem(
             modifier = Modifier.padding(horizontal = 24.dp),
             title = "Package",
-            description = settings.packageName.ifEmpty { "Not specified" },
+            description = generalSettings.packageName.ifEmpty { "Not specified" },
         )
         VerticalSpacer(16.dp)
         WeightSpacer()
@@ -249,22 +247,10 @@ private fun ClearSettingsDialog(
 @Composable
 private fun GeneralSettingsPreview() = PreviewTheme(alignment = Alignment.TopStart) {
     GeneralSettingsUi(
-        settings = ValkyriesSettings(
+        generalSettings = GeneralSettings(
             mode = Simple,
-            previewType = PreviewType.Auto,
             packageName = "io.github.composegears.valkyrie",
-            iconPackPackage = "io.github.composegears.valkyrie",
-            iconPackName = "ValkyrieIcons",
             iconPackDestination = "path/to/export",
-            nestedPacks = emptyList(),
-            outputFormat = OutputFormat.BackingProperty,
-            generatePreview = false,
-            flatPackage = false,
-            useExplicitMode = false,
-            showImageVectorPreview = true,
-            addTrailingComma = true,
-            useMaterialPack = false,
-            indentSize = 4,
         ),
         onChangeMode = {},
         onClearSettings = {},

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/ImageVectorExportSettingsScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/ImageVectorExportSettingsScreen.kt
@@ -3,61 +3,44 @@ package io.github.composegears.valkyrie.ui.screen.settings.tabs.export
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.composegears.tiamat.navDestination
 import com.composegears.tiamat.rememberSharedViewModel
 import io.github.composegears.valkyrie.generator.imagevector.OutputFormat
+import io.github.composegears.valkyrie.generator.imagevector.PreviewAnnotationType
 import io.github.composegears.valkyrie.ui.foundation.VerticalSpacer
-import io.github.composegears.valkyrie.ui.foundation.dim
 import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
+import io.github.composegears.valkyrie.ui.screen.settings.ExportSettings
 import io.github.composegears.valkyrie.ui.screen.settings.SettingsViewModel
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateAddTrailingComma
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateExplicitMode
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateFlatPackage
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateIndentSize
+import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdatePreviewAnnotationType
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdatePreviewGeneration
+import io.github.composegears.valkyrie.ui.screen.settings.tabs.export.ui.SwitchOption
 
 val ImageVectorExportSettingsScreen by navDestination<Unit> {
     val viewModel = rememberSharedViewModel(provider = ::SettingsViewModel)
-    val settings by viewModel.settings.collectAsState()
+    val exportSettings by viewModel.exportSettings.collectAsState()
 
     ImageVectorExportSettingsUi(
         onAction = viewModel::onAction,
-        outputFormat = settings.outputFormat,
-        generatePreview = settings.generatePreview,
-        useFlatPackage = settings.flatPackage,
-        useExplicitMode = settings.useExplicitMode,
-        indentSize = settings.indentSize,
-        addTrailingComma = settings.addTrailingComma,
+        exportSettings = exportSettings,
     )
 }
 
 @Composable
 private fun ImageVectorExportSettingsUi(
-    outputFormat: OutputFormat,
-    generatePreview: Boolean,
-    useFlatPackage: Boolean,
-    useExplicitMode: Boolean,
-    addTrailingComma: Boolean,
-    indentSize: Int,
+    exportSettings: ExportSettings,
     onAction: (SettingsAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -68,75 +51,42 @@ private fun ImageVectorExportSettingsUi(
     ) {
         VerticalSpacer(16.dp)
         OutputFormatSection(
-            outputFormat = outputFormat,
+            outputFormat = exportSettings.outputFormat,
             onAction = onAction,
         )
         VerticalSpacer(16.dp)
         SwitchOption(
             title = "Use flat package",
             description = "Export all ImageVector icons into a single package without dividing by nested pack folders",
-            checked = useFlatPackage,
+            checked = exportSettings.useFlatPackage,
             onCheckedChange = { onAction(UpdateFlatPackage(it)) },
         )
         SwitchOption(
             title = "Handle Kotlin explicit mode",
             description = "Generate ImageVector icons and IconPack with explicit 'public' modifier",
-            checked = useExplicitMode,
+            checked = exportSettings.useExplicitMode,
             onCheckedChange = { onAction(UpdateExplicitMode(it)) },
         )
         SwitchOption(
             title = "Add trailing comma",
             description = "Insert a comma after the last element of ImageVector.Builder block and path params",
-            checked = addTrailingComma,
+            checked = exportSettings.addTrailingComma,
             onCheckedChange = { onAction(UpdateAddTrailingComma(it)) },
         )
-        SwitchOption(
-            title = "Include @Preview block",
-            description = "Note: Deprecated option, please consider to use build-in ImageVector preview feature",
-            checked = generatePreview,
-            onCheckedChange = { onAction(UpdatePreviewGeneration(it)) },
+        VerticalSpacer(16.dp)
+        PreviewAnnotationSection(
+            generatePreview = exportSettings.generatePreview,
+            previewAnnotationType = exportSettings.previewAnnotationType,
+            onGeneratePreviewChange = { onAction(UpdatePreviewGeneration(it)) },
+            onAnnotationTypeChange = { onAction(UpdatePreviewAnnotationType(it)) },
         )
+        VerticalSpacer(16.dp)
         IndentSizeSection(
-            indent = indentSize,
+            indent = exportSettings.indentSize,
             onValueChange = { onAction(UpdateIndentSize(it)) },
         )
         VerticalSpacer(16.dp)
     }
-}
-
-@Composable
-private fun SwitchOption(
-    title: String,
-    description: String,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-) {
-    ListItem(
-        modifier = Modifier
-            .toggleable(
-                value = checked,
-                onValueChange = onCheckedChange,
-            )
-            .padding(horizontal = 8.dp)
-            .heightIn(max = 100.dp),
-        headlineContent = {
-            Text(text = title)
-        },
-        supportingContent = {
-            Text(
-                text = description,
-                style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
-                color = LocalContentColor.current.dim(),
-            )
-        },
-        trailingContent = {
-            Switch(
-                modifier = Modifier.scale(0.9f),
-                checked = checked,
-                onCheckedChange = onCheckedChange,
-            )
-        },
-    )
 }
 
 @Preview
@@ -144,11 +94,14 @@ private fun SwitchOption(
 private fun ImageVectorExportSettingsPreview() = PreviewTheme(alignment = Alignment.TopStart) {
     ImageVectorExportSettingsUi(
         onAction = {},
-        outputFormat = OutputFormat.BackingProperty,
-        generatePreview = false,
-        useFlatPackage = true,
-        useExplicitMode = false,
-        addTrailingComma = false,
-        indentSize = 4,
+        exportSettings = ExportSettings(
+            outputFormat = OutputFormat.BackingProperty,
+            generatePreview = true,
+            useFlatPackage = true,
+            useExplicitMode = false,
+            addTrailingComma = false,
+            indentSize = 4,
+            previewAnnotationType = PreviewAnnotationType.Jetbrains,
+        ),
     )
 }

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/OutputFormatSection.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/OutputFormatSection.kt
@@ -1,33 +1,27 @@
 package io.github.composegears.valkyrie.ui.screen.settings.tabs.export
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import dev.snipme.highlights.Highlights
 import io.github.composegears.valkyrie.generator.imagevector.OutputFormat
 import io.github.composegears.valkyrie.generator.imagevector.OutputFormat.BackingProperty
 import io.github.composegears.valkyrie.generator.imagevector.OutputFormat.LazyProperty
-import io.github.composegears.valkyrie.ui.foundation.CenterVerticalRow
 import io.github.composegears.valkyrie.ui.foundation.VerticalSpacer
-import io.github.composegears.valkyrie.ui.foundation.highlights.CodeViewerTooltip
 import io.github.composegears.valkyrie.ui.foundation.highlights.core.rememberCodeHighlight
 import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateOutputFormat
+import io.github.composegears.valkyrie.ui.screen.settings.tabs.export.ui.SelectableCard
 
 @Composable
 fun OutputFormatSection(
@@ -62,42 +56,6 @@ fun OutputFormatSection(
                 highlights = rememberCodeHighlight(lazyPropertyFormat),
                 isSelected = outputFormat == LazyProperty,
                 onSelect = { onAction(UpdateOutputFormat(LazyProperty)) },
-            )
-        }
-    }
-}
-
-@Composable
-private fun SelectableCard(
-    text: String,
-    highlights: Highlights,
-    isSelected: Boolean,
-    modifier: Modifier = Modifier,
-    onSelect: () -> Unit,
-) {
-    Card(
-        modifier = modifier.requiredHeight(72.dp),
-        onClick = onSelect,
-        border = if (isSelected) {
-            BorderStroke(
-                width = 1.dp,
-                color = MaterialTheme.colorScheme.primary,
-            )
-        } else {
-            null
-        },
-    ) {
-        CenterVerticalRow(modifier = Modifier.fillMaxHeight()) {
-            Text(
-                modifier = Modifier
-                    .padding(16.dp)
-                    .weight(1f),
-                text = text,
-                style = MaterialTheme.typography.bodySmall,
-            )
-            CodeViewerTooltip(
-                modifier = Modifier.padding(end = 16.dp),
-                highlights = highlights,
             )
         }
     }

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/PreviewAnnotationSection.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/PreviewAnnotationSection.kt
@@ -1,0 +1,101 @@
+package io.github.composegears.valkyrie.ui.screen.settings.tabs.export
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.composegears.valkyrie.generator.imagevector.PreviewAnnotationType
+import io.github.composegears.valkyrie.generator.imagevector.PreviewAnnotationType.AndroidX
+import io.github.composegears.valkyrie.generator.imagevector.PreviewAnnotationType.Jetbrains
+import io.github.composegears.valkyrie.ui.foundation.VerticalSpacer
+import io.github.composegears.valkyrie.ui.foundation.highlights.core.rememberCodeHighlight
+import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
+import io.github.composegears.valkyrie.ui.screen.settings.tabs.export.ui.SelectableCard
+import io.github.composegears.valkyrie.ui.screen.settings.tabs.export.ui.SwitchOption
+
+@Composable
+fun PreviewAnnotationSection(
+    generatePreview: Boolean,
+    previewAnnotationType: PreviewAnnotationType,
+    onGeneratePreviewChange: (Boolean) -> Unit,
+    onAnnotationTypeChange: (PreviewAnnotationType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        SwitchOption(
+            title = "Add @Preview annotation",
+            description = "Note: This option is deprecated. Consider using the built-in ImageVector previewer instead",
+            checked = generatePreview,
+            onCheckedChange = onGeneratePreviewChange,
+        )
+        AnimatedVisibility(
+            visible = generatePreview,
+            enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut(),
+        ) {
+            Column {
+                VerticalSpacer(8.dp)
+                Row(
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    SelectableCard(
+                        modifier = Modifier.weight(1f),
+                        text = "AndroidX Preview",
+                        highlights = rememberCodeHighlight(
+                            """
+                               import androidx.compose.ui.tooling.preview.Preview
+
+                               @Preview
+                               @Composable
+                               fun MyIconPreview() {
+                                   Icon(imageVector = Icons.Filled.MyIcon)
+                               }
+                            """.trimIndent(),
+                        ),
+                        isSelected = previewAnnotationType == AndroidX,
+                        onSelect = { onAnnotationTypeChange(AndroidX) },
+                    )
+
+                    SelectableCard(
+                        modifier = Modifier.weight(1f),
+                        text = "JetBrains Preview",
+                        highlights = rememberCodeHighlight(
+                            """
+                               import androidx.compose.desktop.ui.tooling.preview.Preview
+
+                               @Preview
+                               @Composable
+                               fun MyIconPreview() {
+                                   Icon(imageVector = Icons.Filled.MyIcon)
+                               }
+                            """.trimIndent(),
+                        ),
+                        isSelected = previewAnnotationType == Jetbrains,
+                        onSelect = { onAnnotationTypeChange(Jetbrains) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewAnnotationSectionPreview() = PreviewTheme {
+    PreviewAnnotationSection(
+        generatePreview = true,
+        previewAnnotationType = AndroidX,
+        onGeneratePreviewChange = {},
+        onAnnotationTypeChange = {},
+    )
+}

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/ui/SelectableCard.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/ui/SelectableCard.kt
@@ -1,0 +1,97 @@
+package io.github.composegears.valkyrie.ui.screen.settings.tabs.export.ui
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.snipme.highlights.Highlights
+import io.github.composegears.valkyrie.ui.foundation.CenterVerticalRow
+import io.github.composegears.valkyrie.ui.foundation.highlights.CodeViewerTooltip
+import io.github.composegears.valkyrie.ui.foundation.highlights.core.rememberCodeHighlight
+import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
+
+@Composable
+fun SelectableCard(
+    text: String,
+    highlights: Highlights,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+    onSelect: () -> Unit,
+) {
+    Card(
+        modifier = modifier.requiredHeight(72.dp),
+        onClick = onSelect,
+        border = if (isSelected) {
+            BorderStroke(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        } else {
+            null
+        },
+    ) {
+        CenterVerticalRow(modifier = Modifier.fillMaxHeight()) {
+            Text(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .weight(1f),
+                text = text,
+                style = MaterialTheme.typography.bodySmall,
+            )
+            CodeViewerTooltip(
+                modifier = Modifier.padding(end = 16.dp),
+                highlights = highlights,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SelectableCardPreview() = PreviewTheme {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        SelectableCard(
+            modifier = Modifier.width(300.dp),
+            text = "Selected Card",
+            highlights = rememberCodeHighlight(
+                """
+                val MyIcon = ImageVector.Builder()
+                    .width(24.dp)
+                    .height(24.dp)
+                    .build()
+                """.trimIndent(),
+            ),
+            isSelected = true,
+            onSelect = {},
+        )
+        SelectableCard(
+            modifier = Modifier.width(300.dp),
+            text = "Unselected Card",
+            highlights = rememberCodeHighlight(
+                """
+                val MyIcon by lazy {
+                    ImageVector.Builder()
+                        .width(24.dp)
+                        .height(24.dp)
+                        .build()
+                }
+                """.trimIndent(),
+            ),
+            isSelected = false,
+            onSelect = {},
+        )
+    }
+}

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/ui/SwitchOption.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/export/ui/SwitchOption.kt
@@ -1,0 +1,75 @@
+package io.github.composegears.valkyrie.ui.screen.settings.tabs.export.ui
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.composegears.valkyrie.ui.foundation.dim
+import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
+
+@Composable
+fun SwitchOption(
+    title: String,
+    description: String,
+    checked: Boolean,
+    modifier: Modifier = Modifier,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    ListItem(
+        modifier = modifier
+            .toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+            )
+            .padding(horizontal = 8.dp)
+            .heightIn(max = 100.dp),
+        headlineContent = {
+            Text(text = title)
+        },
+        supportingContent = {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                color = LocalContentColor.current.dim(),
+            )
+        },
+        trailingContent = {
+            Switch(
+                modifier = Modifier.scale(0.9f),
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+            )
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun SwitchOptionPreview() = PreviewTheme {
+    Column {
+        SwitchOption(
+            title = "Example Option",
+            description = "This is a description of what this option does",
+            checked = false,
+            onCheckedChange = {},
+        )
+
+        SwitchOption(
+            title = "Enabled Option",
+            description = "This option is currently enabled",
+            checked = true,
+            onCheckedChange = {},
+        )
+    }
+}

--- a/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/preview/ImageVectorPreviewSettingsScreen.kt
+++ b/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/preview/ImageVectorPreviewSettingsScreen.kt
@@ -25,6 +25,7 @@ import io.github.composegears.valkyrie.ui.domain.model.PreviewType
 import io.github.composegears.valkyrie.ui.foundation.VerticalSpacer
 import io.github.composegears.valkyrie.ui.foundation.dim
 import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
+import io.github.composegears.valkyrie.ui.screen.settings.PreviewSettings
 import io.github.composegears.valkyrie.ui.screen.settings.SettingsViewModel
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateImageVectorPreview
@@ -32,19 +33,17 @@ import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.U
 
 val ImageVectorPreviewSettingsScreen by navDestination<Unit> {
     val viewModel = rememberSharedViewModel(provider = ::SettingsViewModel)
-    val settings by viewModel.settings.collectAsState()
+    val previewSettings by viewModel.previewSettings.collectAsState()
 
     ImageVectorPreviewSettingsUi(
-        showImageVectorPreview = settings.showImageVectorPreview,
-        previewType = settings.previewType,
+        previewSettings = previewSettings,
         onAction = viewModel::onAction,
     )
 }
 
 @Composable
 private fun ImageVectorPreviewSettingsUi(
-    showImageVectorPreview: Boolean,
-    previewType: PreviewType,
+    previewSettings: PreviewSettings,
     modifier: Modifier = Modifier,
     onAction: (SettingsAction) -> Unit,
 ) {
@@ -53,7 +52,7 @@ private fun ImageVectorPreviewSettingsUi(
         ListItem(
             modifier = Modifier
                 .toggleable(
-                    value = showImageVectorPreview,
+                    value = previewSettings.showImageVectorPreview,
                     onValueChange = { onAction(UpdateImageVectorPreview(it)) },
                 )
                 .padding(horizontal = 8.dp)
@@ -71,14 +70,14 @@ private fun ImageVectorPreviewSettingsUi(
             trailingContent = {
                 Switch(
                     modifier = Modifier.scale(0.9f),
-                    checked = showImageVectorPreview,
+                    checked = previewSettings.showImageVectorPreview,
                     onCheckedChange = { onAction(UpdateImageVectorPreview(it)) },
                 )
             },
         )
         VerticalSpacer(16.dp)
         PreviewBgSection(
-            previewType = previewType,
+            previewType = previewSettings.previewType,
             onSelect = { onAction(UpdatePreviewType(it)) },
         )
     }
@@ -88,8 +87,10 @@ private fun ImageVectorPreviewSettingsUi(
 @Composable
 private fun ImageVectorPreviewSettingsPreview() = PreviewTheme(alignment = Alignment.TopStart) {
     ImageVectorPreviewSettingsUi(
-        showImageVectorPreview = true,
-        previewType = PreviewType.Auto,
+        previewSettings = PreviewSettings(
+            showImageVectorPreview = true,
+            previewType = PreviewType.Auto,
+        ),
         onAction = {},
     )
 }


### PR DESCRIPTION
Also:
- Refactor settings to use specific data classes for general, export, and preview settings


Related to: #372 
CLI and integration will be done in next ticket



https://github.com/user-attachments/assets/83ac7d93-89bb-418a-8a15-d4d8d3bd53b0

