### PR TITLE
Fix plugin not dynamic due to missing id

### DIFF
--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -38,7 +38,7 @@ Allows to create organized icon pack with an extension property of you pack obje
             popup="true">
 
             <separator/>
-            <group>
+            <group id="valkyrie.SubGroup">
                 <action id="valkyrie.ImportFromAction"
                         icon="com.intellij.icons.AllIcons.ToolbarDecorator.Import"
                         class="io.github.composegears.valkyrie.action.ImportFromDirectoryOrFileAction"


### PR DESCRIPTION
Fix error:

```
Execution failed for task ':idea-plugin:verifyPlugin'.
> NOT_DYNAMIC: Plugin probably cannot be enabled or disabled without IDE restart. Check Plugin Verifier report for more details.
  Incompatible API Changes: https://jb.gg/intellij-api-changes
```
https://github.com/ComposeGears/Valkyrie/actions/runs/14700664599

Also reported issue: https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/issues/86