### PR TITLE
Add gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ material icons.
 
 - IntelliJ IDEA / Android Studio plugin
 - CLI tool
-- Gradle plugin and Web app (🚧 coming soon 🚧)
+- Gradle plugin 
+- Web app (🚧 coming soon 🚧)
 
 ## IDEA Plugin
 

--- a/components/extensions/src/jvmMain/kotlin/io/github/composegears/valkyrie/extensions/PathUtils.kt
+++ b/components/extensions/src/jvmMain/kotlin/io/github/composegears/valkyrie/extensions/PathUtils.kt
@@ -1,6 +1,7 @@
 package io.github.composegears.valkyrie.extensions
 
 import java.io.IOException
+import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.deleteIfExists
@@ -12,7 +13,7 @@ fun String.writeToKt(
     nameWithoutExtension: String,
     deleteIfExists: Boolean = true,
     createParents: Boolean = true,
-) {
+): Path {
     val outputPath = Path(outputDir, "$nameWithoutExtension.kt")
 
     if (deleteIfExists) {
@@ -22,4 +23,5 @@ fun String.writeToKt(
         outputPath.createParentDirectories()
     }
     outputPath.writeText(this)
+    return outputPath
 }

--- a/components/parser/unified/src/jvmMain/kotlin/io/github/composegears/valkyrie/parser/unified/ext/Path.jvm.kt
+++ b/components/parser/unified/src/jvmMain/kotlin/io/github/composegears/valkyrie/parser/unified/ext/Path.jvm.kt
@@ -1,5 +1,6 @@
 package io.github.composegears.valkyrie.parser.unified.ext
 
+import java.io.File
 import java.nio.file.Path as NioPath
 import java.nio.file.Paths
 import kotlinx.io.files.Path
@@ -7,3 +8,5 @@ import kotlinx.io.files.Path
 fun Path.toJvmPath(): NioPath = Paths.get(this.toString())
 
 fun NioPath.toIOPath(): Path = Path(this.toString())
+
+fun File.toIOPath(): Path = Path(absolutePath)

--- a/components/test/coverage/build.gradle.kts
+++ b/components/test/coverage/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     // include only necessary dependencies for the test coverage
     kover(projects.tools.cli)
+    kover(projects.tools.gradlePlugin)
     kover(projects.components.generator.jvm.common)
     kover(projects.components.generator.jvm.iconpack)
     kover(projects.components.generator.jvm.imagevector)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,9 @@ mockk = "io.mockk:mockk:1.14.2"
 ktlint = "com.pinterest.ktlint:ktlint-cli:1.6.0"
 composeRules = "io.nlopez.compose.rules:ktlint:0.4.22"
 
+gradle-agp = { module = "com.android.tools.build:gradle", version = "8.10.0" }
+gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
 # Dependencies for build-logic module
 kotlin-compose-compiler-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,6 +48,7 @@ includeBuild("build-logic")
 
 include("tools:cli")
 include("tools:compose-app")
+include("tools:gradle-plugin")
 include("tools:idea-plugin")
 
 include("components:extensions")

--- a/tools/gradle-plugin/build.gradle.kts
+++ b/tools/gradle-plugin/build.gradle.kts
@@ -1,0 +1,79 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.buildConfig)
+    `java-gradle-plugin`
+}
+
+tasks.validatePlugins {
+    enableStricterValidation = true
+}
+
+val originUrl = providers
+    .exec { commandLine("git", "remote", "get-url", "origin") }
+    .standardOutput
+    .asText
+    .map { it.trim() }
+
+gradlePlugin {
+    vcsUrl = originUrl
+    website = originUrl
+
+    plugins {
+        create("valkyrie") {
+            id = "io.github.composegears.valkyrie"
+            displayName = name
+            implementationClass = "io.github.composegears.valkyrie.gradle.ValkyrieGradlePlugin"
+            description = "Generates Kotlin accessors for ImageVectors, based on input SVG files"
+            tags.addAll("kotlin", "svg", "xml", "imagevector", "valkyrie")
+        }
+    }
+}
+
+buildConfig {
+    generateAtSync = true
+    sourceSets.getByName("test") {
+        packageName = "io.github.composegears.valkyrie.gradle"
+        useKotlinOutput {
+            internalVisibility = true
+            topLevelConstants = true
+        }
+
+        // TODO: Set up test matrix for different gradle/agp/kotlin version combos?
+        buildConfigField("AGP_VERSION", libs.gradle.agp.get().version)
+        buildConfigField("KOTLIN_VERSION", libs.gradle.kotlin.get().version)
+        buildConfigField("GRADLE_VERSION", "8.14.1")
+
+        fun Project.sharedTestResourcesDir(name: String) = project
+            .project(projects.components.test.path)
+            .layout
+            .projectDirectory
+            .dir("sharedTestResources/imagevector/$name")
+            .asFile
+            .absolutePath
+
+        // So we can copy the shared test SVG/XML files into our test cases
+        buildConfigField("SAMPLE_SVG_DIR", sharedTestResourcesDir("svg"))
+        buildConfigField("SAMPLE_XML_DIR", sharedTestResourcesDir("xml"))
+    }
+}
+
+dependencies {
+    compileOnly(gradleApi())
+    compileOnly(gradleKotlinDsl())
+
+    implementation(libs.gradle.agp)
+    implementation(libs.gradle.kotlin)
+
+    api(projects.components.extensions)
+    api(projects.components.generator.jvm.iconpack)
+    api(projects.components.generator.jvm.imagevector)
+    api(projects.components.ir)
+    api(projects.components.parser.unified)
+
+    testImplementation(gradleTestKit())
+    testImplementation(gradleKotlinDsl())
+    testImplementation(libs.gradle.agp)
+    testImplementation(libs.gradle.kotlin)
+    testImplementation(libs.junit5.jupiter)
+    testImplementation(libs.kotlin.test)
+}

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/GenerateSvgImageVectorTask.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/GenerateSvgImageVectorTask.kt
@@ -1,0 +1,97 @@
+package io.github.composegears.valkyrie.gradle
+
+import io.github.composegears.valkyrie.extensions.writeToKt
+import io.github.composegears.valkyrie.generator.jvm.imagevector.ImageVectorGenerator
+import io.github.composegears.valkyrie.generator.jvm.imagevector.ImageVectorGeneratorConfig
+import io.github.composegears.valkyrie.parser.unified.ParserType
+import io.github.composegears.valkyrie.parser.unified.SvgXmlParser
+import io.github.composegears.valkyrie.parser.unified.ext.toIOPath
+import java.nio.file.Path
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.property
+
+@CacheableTask
+open class GenerateSvgImageVectorTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    @get:InputFiles
+    val svgFiles: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    @get:InputFiles
+    val drawableFiles: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:Input val packageName: Property<String> = objects.property<String>()
+
+    @get:Input val outputSourceSet: Property<String> = objects.property<String>()
+
+    @get:Nested val config: Property<ValkyrieConfig> = objects.property<ValkyrieConfig>()
+
+    @get:OutputDirectory val outputDirectory: DirectoryProperty = objects.directoryProperty()
+
+    @TaskAction
+    fun execute() = with(config.get()) {
+        val packageName = packageName.get()
+        val outputDirectory = outputDirectory.get().asFile
+        outputDirectory.delete() // make sure nothing is left over from previous run
+        outputDirectory.mkdirs()
+
+        // e.g. "<project-root>/build/generated/sources/valkyrie/main"
+        val sourceSetDirectory = outputDirectory.resolve(outputSourceSet.get())
+
+        val generatedFiles = arrayListOf<Path>()
+        var fileIndex = 0
+
+        (svgFiles + drawableFiles).files.forEach { file ->
+            val parseOutput = SvgXmlParser.toIrImageVector(ParserType.Jvm, file.toIOPath())
+            val config = ImageVectorGeneratorConfig(
+                packageName = packageName,
+                iconPackPackage = packageName,
+                packName = iconPackName,
+                nestedPackName = nestedPackName,
+                outputFormat = outputFormat,
+                useComposeColors = useComposeColors,
+                generatePreview = generatePreview,
+                previewAnnotationType = previewAnnotationType,
+                useFlatPackage = useFlatPackage,
+                useExplicitMode = useExplicitMode,
+                addTrailingComma = addTrailingComma,
+                indentSize = indentSize,
+            )
+            val vectorSpecOutput = ImageVectorGenerator.convert(
+                vector = parseOutput.irImageVector,
+                iconName = parseOutput.iconName,
+                config = config,
+            )
+
+            val path = vectorSpecOutput.content.writeToKt(
+                outputDir = when {
+                    useFlatPackage -> sourceSetDirectory
+                    else -> sourceSetDirectory.resolve(nestedPackName.lowercase())
+                }.absolutePath,
+                nameWithoutExtension = vectorSpecOutput.name,
+            )
+            generatedFiles.add(path)
+            fileIndex++
+            logger.info("File $fileIndex = $path")
+        }
+
+        logger.lifecycle("Generated ${generatedFiles.size} ImageVectors in package $packageName")
+    }
+
+    companion object {
+        const val TASK_NAME = "generateSvgImageVector"
+    }
+}

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieConfig.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieConfig.kt
@@ -1,0 +1,21 @@
+package io.github.composegears.valkyrie.gradle
+
+import io.github.composegears.valkyrie.generator.jvm.imagevector.OutputFormat
+import io.github.composegears.valkyrie.generator.jvm.imagevector.PreviewAnnotationType
+import org.gradle.api.tasks.Input
+
+/**
+ * Uses the same defaults as SvgXmlToImageVectorCommand in tools/cli.
+ */
+data class ValkyrieConfig @JvmOverloads constructor(
+    @get:Input var iconPackName: String = "",
+    @get:Input var nestedPackName: String = "",
+    @get:Input var outputFormat: OutputFormat = OutputFormat.BackingProperty,
+    @get:Input var useComposeColors: Boolean = true,
+    @get:Input var generatePreview: Boolean = false,
+    @get:Input var previewAnnotationType: PreviewAnnotationType = PreviewAnnotationType.AndroidX,
+    @get:Input var useFlatPackage: Boolean = false,
+    @get:Input var useExplicitMode: Boolean = false,
+    @get:Input var addTrailingComma: Boolean = false,
+    @get:Input var indentSize: Int = 4,
+)

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieExtension.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieExtension.kt
@@ -1,0 +1,50 @@
+package io.github.composegears.valkyrie.gradle
+
+import javax.inject.Inject
+import org.gradle.api.Action
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.property
+
+open class ValkyrieExtension @Inject constructor(objects: ObjectFactory, layout: ProjectLayout) {
+    /**
+     * Package name of the generated accessors. If you have any Android gradle plugin applied, this will default to
+     * the [com.android.build.api.dsl.CommonExtension.namespace] property - or fail otherwise.
+     */
+    val packageName: Property<String> = objects
+        .property<String>()
+        .unsetConvention()
+
+    /**
+     * When true, accessor generation will be re-run when clicking Sync in the IntelliJ IDE UI. Disabled by default.
+     */
+    val generateAtSync: Property<Boolean> = objects
+        .property<Boolean>()
+        .convention(false)
+
+    /**
+     * Source set to dump the generated classes into. Defaults to "main", unless you're using Kotlin Multiplatform in
+     * which case it defaults to "commonMain".
+     */
+    val outputSourceSet: Property<String> = objects
+        .property<String>()
+        .unsetConvention()
+
+    /**
+     * Output location of the generated files. Defaults to "<project-dir>/build/generated/sources/valkyrie".
+     */
+    val outputDirectory: DirectoryProperty = objects
+        .directoryProperty()
+        .convention(layout.buildDirectory.dir("generated/sources/valkyrie"))
+
+    /**
+     * Adjusts the various configuration options. See [ValkyrieConfig] for default parameters.
+     */
+    fun configure(action: Action<ValkyrieConfig>) {
+        action.execute(config)
+    }
+
+    internal val config = ValkyrieConfig()
+}

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieGradlePlugin.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieGradlePlugin.kt
@@ -1,0 +1,84 @@
+package io.github.composegears.valkyrie.gradle
+
+import com.android.build.api.dsl.CommonExtension
+import io.github.composegears.valkyrie.gradle.GenerateSvgImageVectorTask.Companion.TASK_NAME
+import java.io.File
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
+
+class ValkyrieGradlePlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        val extension = extensions.create(name = "valkyrie", type = ValkyrieExtension::class)
+
+        val svgTask = tasks.register<GenerateSvgImageVectorTask>(TASK_NAME) {
+            group = "build"
+            description = "Converts SVG files into generated ImageVector Kotlin accessor properties"
+            svgFiles.setFrom(findSvgFiles())
+            drawableFiles.setFrom(findDrawableFiles())
+            packageName.set(extension.packageName.orNull ?: estimatePackageNameOrThrow())
+            config.set(extension.config)
+            outputSourceSet.set(extension.outputSourceSet.orNull ?: estimateSourceSet())
+            outputDirectory.set(extension.outputDirectory)
+        }
+
+        afterEvaluate {
+            // Run generation immediately if we're syncing Intellij/Android Studio - helps to speed up dev cycle
+            val isIdeSyncing = System.getProperty("idea.sync.active") == "true"
+            if (extension.generateAtSync.get() && isIdeSyncing) {
+                tasks.maybeCreate("prepareKotlinIdeaImport").dependsOn(svgTask)
+            }
+
+            // Run generation before any kind of kotlin source processing
+            tasks.withType(AbstractKotlinCompile::class).configureEach { it.dependsOn(svgTask) }
+        }
+    }
+
+    private fun Project.estimatePackageNameOrThrow(): String {
+        val androidPluginIds = listOf(
+            "com.android.application",
+            "com.android.library",
+            "com.android.test",
+        )
+        if (androidPluginIds.any(pluginManager::hasPlugin)) {
+            return extensions
+                .findByType(CommonExtension::class)
+                ?.namespace
+                ?: throw GradleException(NO_PACKAGE_NAME_ERROR)
+        }
+        throw GradleException(NO_PACKAGE_NAME_ERROR)
+    }
+
+    private fun Project.estimateSourceSet() = if (plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
+        KotlinSourceSet.COMMON_MAIN_SOURCE_SET_NAME
+    } else {
+        SourceSet.MAIN_SOURCE_SET_NAME
+    }
+
+    private fun Project.findSvgFiles(): Set<File> = layout.projectDirectory
+        .dir("src/${estimateSourceSet()}/svg")
+        .asFileTree
+        .filter { it.extension == "svg" }
+        .files
+
+    private fun Project.findDrawableFiles(): Set<File> = layout.projectDirectory
+        .dir("src/${estimateSourceSet()}/res")
+        .asFileTree
+        .filter { it.parentFile?.name.orEmpty().contains("drawable") && it.extension == "xml" }
+        .files
+}
+
+private val NO_PACKAGE_NAME_ERROR = """
+    Couldn't automatically estimate package name - make sure to set this property in your gradle script like:
+
+    valkyrie {
+        packageName = "my.output.package.name"
+    }
+""".trimIndent()

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/Utils.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/Utils.kt
@@ -1,0 +1,52 @@
+package io.github.composegears.valkyrie.gradle
+
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+
+internal fun runTask(root: File, task: String) = GradleRunner
+    .create()
+    .withDebug(true)
+    .withPluginClasspath()
+    .withGradleVersion(GRADLE_VERSION)
+    .withProjectDir(root)
+    .withArguments(task, "--info", "--stacktrace")
+
+internal fun runTaskWithConfigurationCache(root: File, task: String) = GradleRunner
+    .create()
+    .withDebug(true)
+    .withPluginClasspath()
+    .withGradleVersion(GRADLE_VERSION)
+    .withProjectDir(root)
+    .withArguments(task, "--configuration-cache", "--info", "--stacktrace")
+
+internal fun File.writeSettingsFile() = resolve("settings.gradle.kts").writeText(
+    """
+        pluginManagement {
+            repositories {
+                mavenCentral()
+                google()
+                gradlePluginPortal()
+            }
+        }
+
+        dependencyResolutionManagement {
+            repositories {
+                mavenCentral()
+                google()
+            }
+        }
+    """.trimIndent(),
+)
+
+internal fun File.writeLibsTomlFile() = resolve("gradle")
+    .also { it.mkdirs() }
+    .resolve("libs.versions.toml")
+    .writeText(
+        """
+            [plugins]
+            agpLib = { id = "com.android.library", version = "$AGP_VERSION" }
+            kotlinAndroid = { id = "org.jetbrains.kotlin.android", version = "$KOTLIN_VERSION" }
+            kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version = "$KOTLIN_VERSION" }
+            kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version = "$KOTLIN_VERSION" }
+        """.trimIndent(),
+    )

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieGradlePluginTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieGradlePluginTest.kt
@@ -1,0 +1,301 @@
+package io.github.composegears.valkyrie.gradle
+
+import io.github.composegears.valkyrie.gradle.GenerateSvgImageVectorTask.Companion.TASK_NAME
+import java.io.File
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import org.gradle.api.internal.project.DefaultProject
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class ValkyrieGradlePluginTest {
+    @TempDir lateinit var root: File
+
+    private lateinit var project: DefaultProject
+
+    @BeforeEach
+    fun before() {
+        root.writeLibsTomlFile()
+        root.writeSettingsFile()
+        project = ProjectBuilder
+            .builder()
+            .withProjectDir(root)
+            .build()
+            as DefaultProject
+    }
+
+    @Test
+    fun `Package name doesn't need to be explicitly set if AGP is applied and namespace is set`() {
+        // given
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    alias(libs.plugins.kotlinAndroid)
+                    alias(libs.plugins.agpLib)
+                    id("io.github.composegears.valkyrie")
+                }
+
+                android {
+                    namespace = "a.b.c"
+                    compileSdk = 33
+                }
+            """.trimIndent(),
+        )
+
+        // when
+        val result = runTask(root, TASK_NAME).build()
+
+        // then
+        assertEquals(TaskOutcome.SUCCESS, result.task(":$TASK_NAME")?.outcome)
+        assertContains(result.output, "Generated 0 ImageVectors in package a.b.c")
+    }
+
+    @Test
+    fun `Package name does need to be explicitly set if AGP isn't applied`() {
+        // given
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    alias(libs.plugins.kotlinJvm)
+                    id("io.github.composegears.valkyrie")
+                }
+            """.trimIndent(),
+        )
+
+        // when
+        val result = runTask(root, TASK_NAME).buildAndFail()
+
+        // then
+        assertContains(result.output, "Could not create task ':$TASK_NAME'")
+        assertContains(result.output, "Couldn't automatically estimate package name")
+    }
+
+    @Test
+    fun `Setting custom package name`() {
+        // given
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    alias(libs.plugins.kotlinJvm)
+                    id("io.github.composegears.valkyrie")
+                }
+
+                valkyrie {
+                    packageName = "x.y.z"
+                }
+            """.trimIndent(),
+        )
+
+        // when
+        val result = runTask(root, TASK_NAME).build()
+
+        // then
+        assertEquals(TaskOutcome.SUCCESS, result.task(":$TASK_NAME")?.outcome)
+        assertContains(result.output, "Generated 0 ImageVectors in package x.y.z")
+    }
+
+    @Test
+    fun `Generate from SVGs with default config`() {
+        // given
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    alias(libs.plugins.kotlinJvm)
+                    id("io.github.composegears.valkyrie")
+                }
+
+                valkyrie {
+                    packageName = "x.y.z"
+                }
+            """.trimIndent(),
+        )
+
+        writeTestSvgs()
+
+        // when
+        val result = runTask(root, TASK_NAME).build()
+
+        // then
+        assertEquals(TaskOutcome.SUCCESS, result.task(":$TASK_NAME")?.outcome)
+        assertContains(result.output, "Generated 4 ImageVectors in package x.y.z")
+        assertContains(result.output, "LinearGradient.kt")
+        assertContains(result.output, "RadialGradient.kt")
+        assertContains(result.output, "ClipPathGradient.kt")
+        assertContains(result.output, "LinearGradientWithStroke.kt")
+    }
+
+    @Test
+    fun `Generate from test SVGs with custom config`() {
+        // given
+        root.resolve("build.gradle.kts").writeText(
+            """
+                import io.github.composegears.valkyrie.generator.jvm.imagevector.OutputFormat
+                import io.github.composegears.valkyrie.generator.jvm.imagevector.PreviewAnnotationType
+
+                plugins {
+                    alias(libs.plugins.kotlinJvm)
+                    id("io.github.composegears.valkyrie")
+                }
+
+                valkyrie {
+                    packageName = "x.y.z"
+                    configure {
+                        iconPackName = "MyIconPack"
+                        nestedPackName = "MyNestedPack"
+                        outputFormat = OutputFormat.LazyProperty
+                        useComposeColors = false
+                        generatePreview = true
+                        previewAnnotationType = PreviewAnnotationType.Jetbrains
+                        useFlatPackage = true
+                        useExplicitMode = true
+                        addTrailingComma = true
+                        indentSize = 8
+                    }
+                }
+            """.trimIndent(),
+        )
+
+        writeTestSvgs()
+
+        // when
+        val result = runTask(root, TASK_NAME).build()
+
+        // then the expected files are printed to log
+        assertEquals(TaskOutcome.SUCCESS, result.task(":$TASK_NAME")?.outcome)
+        assertContains(result.output, "Generated 4 ImageVectors in package x.y.z")
+        assertContains(result.output, "LinearGradient.kt")
+        assertContains(result.output, "RadialGradient.kt")
+        assertContains(result.output, "ClipPathGradient.kt")
+        assertContains(result.output, "LinearGradientWithStroke.kt")
+
+        // and the LinearGradient file is created with the right visibility, parent pack, nested pack, etc
+        val linearGradientKt = project
+            .fileTree(root)
+            .first { it.name == "LinearGradient.kt" }
+            .readText()
+        assertContains(linearGradientKt, "public val MyIconPack.MyNestedPack.LinearGradient: ImageVector")
+    }
+
+    @Test
+    fun `Generate from SVGs in KMP project`() {
+        // given
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    alias(libs.plugins.kotlinMultiplatform)
+                    alias(libs.plugins.agpLib)
+                    id("io.github.composegears.valkyrie")
+                }
+
+                android {
+                    namespace = "x.y.z"
+                    compileSdk = 35
+                }
+
+                kotlin {
+                    androidTarget()
+                    jvm()
+                }
+            """.trimIndent(),
+        )
+
+        writeTestSvgs(sourceSet = "commonMain")
+
+        // when
+        val result = runTask(root, TASK_NAME).build()
+
+        // then
+        assertEquals(TaskOutcome.SUCCESS, result.task(":$TASK_NAME")?.outcome)
+        assertContains(result.output, "Generated 4 ImageVectors in package x.y.z")
+        assertContains(result.output, "LinearGradient.kt")
+        assertContains(result.output, "RadialGradient.kt")
+        assertContains(result.output, "ClipPathGradient.kt")
+        assertContains(result.output, "LinearGradientWithStroke.kt")
+    }
+
+    @Test
+    fun `Generate from drawables with default config`() {
+        // given
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    alias(libs.plugins.kotlinAndroid)
+                    alias(libs.plugins.agpLib)
+                    id("io.github.composegears.valkyrie")
+                }
+
+                android {
+                    namespace = "x.y.z"
+                    compileSdk = 35
+                }
+            """.trimIndent(),
+        )
+
+        writeTestDrawables()
+
+        // when
+        val result = runTaskWithConfigurationCache(root, TASK_NAME).build()
+
+        // then
+        assertEquals(TaskOutcome.SUCCESS, result.task(":$TASK_NAME")?.outcome)
+        assertContains(result.output, "Generated 13 ImageVectors in package x.y.z")
+        assertContains(result.output, "OnlyPath.kt")
+        assertContains(result.output, "IconWithShorthandColor.kt")
+        assertContains(result.output, "SeveralPath.kt")
+        assertContains(result.output, "AllPathParams.kt")
+        // plus loads others
+    }
+
+    @Test
+    fun `Running the same task twice with configuration cache skips the second run`() {
+        // given
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    alias(libs.plugins.kotlinAndroid)
+                    alias(libs.plugins.agpLib)
+                    id("io.github.composegears.valkyrie")
+                }
+
+                android {
+                    namespace = "x.y.z"
+                    compileSdk = 35
+                }
+            """.trimIndent(),
+        )
+
+        writeTestDrawables()
+        writeTestSvgs()
+
+        // First run generates the outputs
+        val result = runTaskWithConfigurationCache(root, TASK_NAME).build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":$TASK_NAME")?.outcome)
+
+        // Second run doesn't need to - no inputs have changed
+        val result2 = runTaskWithConfigurationCache(root, TASK_NAME).build()
+        assertEquals(TaskOutcome.UP_TO_DATE, result2.task(":$TASK_NAME")?.outcome)
+    }
+
+    private fun writeTestSvgs(sourceSet: String = "main") {
+        val svgDir = root.resolve("src/$sourceSet/svg")
+        svgDir.mkdirs()
+
+        File(SAMPLE_SVG_DIR)
+            .listFiles()
+            .orEmpty()
+            .forEach { file -> file.copyTo(svgDir.resolve(file.name)) }
+    }
+
+    private fun writeTestDrawables(sourceSet: String = "main") {
+        val xmlDir = root.resolve("src/$sourceSet/res/drawable")
+        xmlDir.mkdirs()
+
+        File(SAMPLE_XML_DIR)
+            .listFiles()
+            .orEmpty()
+            .forEach { file -> file.copyTo(xmlDir.resolve(file.name)) }
+    }
+}


### PR DESCRIPTION
As mentioned in https://github.com/ComposeGears/Valkyrie/issues/28, there hasn't yet been a gradle plugin to add to this project. Main use case for me is to help automate the generation logic.

Here's my initial stab at it - it's maybe not 100% fully featured but I thought I'd put it out there and see what people think.

One thing to be aware of: it depends on the various `components` modules. So if/when you publish the gradle plugin, you'll either need to:
- also publish the components modules, or
- figure out some kind of fat-JAR logic to bundle them all together when publishing.

The second one will be a fair bit more complicated than the one you've already done in the CLI app, but it might be possible. Publishing them all is probably best though.