### PR TITLE
Optimize ImageVectorIcon rendering by removing scale dependency and introducing a constant for icon size

### DIFF
--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/completion/ImageVectorIcon.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/completion/ImageVectorIcon.kt
@@ -2,7 +2,6 @@ package io.github.composegears.valkyrie.completion
 
 import com.android.ide.common.vectordrawable.VdPreview
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.ui.scale.JBUIScale
 import java.awt.Component
 import java.awt.Graphics
 import java.awt.Graphics2D
@@ -15,25 +14,20 @@ class ImageVectorIcon(
 ) : Icon {
 
     @Volatile
-    private var lastScale: Float = -1f
-
-    @Volatile
     private var cachedImage: Image? = null
 
     override fun paintIcon(c: Component?, g: Graphics?, x: Int, y: Int) {
         if (g !is Graphics2D) return
-        val scale = JBUIScale.sysScale(g)
 
-        if (cachedImage == null || scale != lastScale) {
-            cachedImage = renderImage(scale)
-            lastScale = scale
+        if (cachedImage == null) {
+            cachedImage = renderImage()
         }
         val img = cachedImage ?: return
         g.drawImage(img, x, y, size, size, null)
     }
 
-    private fun renderImage(scale: Float): Image? {
-        val maxDimension = (size * scale).toInt().coerceAtLeast(1)
+    private fun renderImage(): Image? {
+        val maxDimension = ICON_SCALE_FACTOR * size
         val errorLog = StringBuilder()
 
         val imageBuffer = VdPreview.getPreviewFromVectorXml(
@@ -52,4 +46,8 @@ class ImageVectorIcon(
 
     override fun getIconWidth(): Int = size
     override fun getIconHeight(): Int = size
+
+    companion object {
+        private const val ICON_SCALE_FACTOR = 4
+    }
 }


### PR DESCRIPTION
It will prevent circle icons to be rendered incorrectly

Before 
<img width="460" height="309" alt="Screenshot 2025-10-08 at 11 04 25" src="https://github.com/user-attachments/assets/9b4d906f-dfea-488e-bb3c-584dec69aa79" />

After
<img width="462" height="330" alt="Screenshot 2025-10-08 at 11 06 07" src="https://github.com/user-attachments/assets/8440bba2-e684-4473-a0e2-a34ee7056fd5" />


Before 
<img width="96" height="60" alt="Screenshot 2025-10-08 at 11 04 30" src="https://github.com/user-attachments/assets/8f97cc19-d813-4695-b658-0a4a3d7c1d6e" />

After
<img width="69" height="48" alt="Screenshot 2025-10-08 at 11 06 11" src="https://github.com/user-attachments/assets/1c936835-037c-445e-bd82-d907a9049ae1" />
