### PR TITLE
Handle aspect ratio for ImageVectorIcon rendering in gutter and auto-complete popup

### DIFF
--- a/components/ir/api/ir.api
+++ b/components/ir/api/ir.api
@@ -116,6 +116,10 @@ public final class io/github/composegears/valkyrie/ir/IrImageVector {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/composegears/valkyrie/ir/IrImageVectorKt {
+	public static final fun getAspectRatio (Lio/github/composegears/valkyrie/ir/IrImageVector;)F
+}
+
 public final class io/github/composegears/valkyrie/ir/IrPathFillType : java/lang/Enum {
 	public static final field EvenOdd Lio/github/composegears/valkyrie/ir/IrPathFillType;
 	public static final field NonZero Lio/github/composegears/valkyrie/ir/IrPathFillType;

--- a/components/ir/api/ir.klib.api
+++ b/components/ir/api/ir.klib.api
@@ -658,5 +658,8 @@ final object io.github.composegears.valkyrie.ir.util/ColorClassification { // io
     final fun from(kotlin.collections/List<io.github.composegears.valkyrie.ir/IrColor>): io.github.composegears.valkyrie.ir.util/DominantShade // io.github.composegears.valkyrie.ir.util/ColorClassification.from|from(kotlin.collections.List<io.github.composegears.valkyrie.ir.IrColor>){}[0]
 }
 
+final val io.github.composegears.valkyrie.ir/aspectRatio // io.github.composegears.valkyrie.ir/aspectRatio|@io.github.composegears.valkyrie.ir.IrImageVector{}aspectRatio[0]
+    final fun (io.github.composegears.valkyrie.ir/IrImageVector).<get-aspectRatio>(): kotlin/Float // io.github.composegears.valkyrie.ir/aspectRatio.<get-aspectRatio>|<get-aspectRatio>@io.github.composegears.valkyrie.ir.IrImageVector(){}[0]
+
 final fun (io.github.composegears.valkyrie.ir/IrImageVector).io.github.composegears.valkyrie.ir.util/iconColors(): kotlin.collections/List<io.github.composegears.valkyrie.ir/IrColor> // io.github.composegears.valkyrie.ir.util/iconColors|iconColors@io.github.composegears.valkyrie.ir.IrImageVector(){}[0]
 final fun (kotlin/Char).io.github.composegears.valkyrie.ir.util/toPathNodes(kotlin/FloatArray): kotlin.collections/List<io.github.composegears.valkyrie.ir/IrPathNode> // io.github.composegears.valkyrie.ir.util/toPathNodes|toPathNodes@kotlin.Char(kotlin.FloatArray){}[0]

--- a/components/ir/src/commonMain/kotlin/io/github/composegears/valkyrie/ir/IrImageVector.kt
+++ b/components/ir/src/commonMain/kotlin/io/github/composegears/valkyrie/ir/IrImageVector.kt
@@ -9,3 +9,10 @@ data class IrImageVector(
     val viewportHeight: Float,
     val nodes: List<IrVectorNode>,
 )
+
+val IrImageVector.aspectRatio: Float
+    get() = if (viewportHeight != 0f && viewportWidth != 0f) {
+        viewportWidth / viewportHeight
+    } else {
+        1f
+    }

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/completion/ImageVectorCompletionContributor.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/completion/ImageVectorCompletionContributor.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.lookup.LookupElementPresentation
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import io.github.composegears.valkyrie.extensions.safeAs
+import io.github.composegears.valkyrie.ir.aspectRatio
 import io.github.composegears.valkyrie.ir.xml.toVectorXmlString
 import io.github.composegears.valkyrie.psi.imagevector.ImageVectorPsiParser
 import javax.swing.Icon
@@ -58,11 +59,13 @@ class ImageVectorCompletionContributor : CompletionContributor() {
     }
 
     private fun createIconFromKtFile(ktFile: KtFile): Icon? {
-        val vectorXml = ImageVectorPsiParser.parseToIrImageVector(ktFile)
-            ?.toVectorXmlString()
-            ?: return null
+        val irImageVector = ImageVectorPsiParser.parseToIrImageVector(ktFile)
+        val vectorXml = irImageVector?.toVectorXmlString() ?: return null
 
-        return ImageVectorIcon(vectorXml = vectorXml)
+        return ImageVectorIcon(
+            vectorXml = vectorXml,
+            aspectRatio = irImageVector.aspectRatio,
+        )
     }
 
     private class ComposeColorLookupElementDecorator(

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/completion/ImageVectorIcon.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/completion/ImageVectorIcon.kt
@@ -11,6 +11,7 @@ import javax.swing.Icon
 class ImageVectorIcon(
     private val vectorXml: String,
     private val size: Int = 16,
+    private val aspectRatio: Float,
 ) : Icon {
 
     @Volatile
@@ -23,7 +24,18 @@ class ImageVectorIcon(
             cachedImage = renderImage()
         }
         val img = cachedImage ?: return
-        g.drawImage(img, x, y, size, size, null)
+
+        // Calculate dimensions preserving aspect ratio
+        val (width, height) = when {
+            aspectRatio > 1f -> size to (size / aspectRatio).toInt()
+            else -> (size * aspectRatio).toInt() to size
+        }
+
+        // Center the icon if it's smaller than the allocated space
+        val offsetX = x + (size - width) / 2
+        val offsetY = y + (size - height) / 2
+
+        g.drawImage(img, offsetX, offsetY, width, height, null)
     }
 
     private fun renderImage(): Image? {

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/gutter/ImageVectorGutterProvider.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/gutter/ImageVectorGutterProvider.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.util.CachedValuesManager
 import io.github.composegears.valkyrie.completion.ImageVectorIcon
 import io.github.composegears.valkyrie.extensions.safeAs
 import io.github.composegears.valkyrie.ir.IrImageVector
+import io.github.composegears.valkyrie.ir.aspectRatio
 import io.github.composegears.valkyrie.ir.xml.toVectorXmlString
 import io.github.composegears.valkyrie.psi.imagevector.ImageVectorPsiParser
 import javax.swing.Icon
@@ -83,7 +84,10 @@ class ImageVectorGutterProvider : LineMarkerProvider {
         val irImageVector = parseImageVectorProperty(this) ?: return null
         val vectorXml = irImageVector.toVectorXmlString()
 
-        return ImageVectorIcon(vectorXml = vectorXml)
+        return ImageVectorIcon(
+            vectorXml = vectorXml,
+            aspectRatio = irImageVector.aspectRatio,
+        )
     }
 
     private fun parseImageVectorProperty(property: KtProperty): IrImageVector? {


### PR DESCRIPTION
Gutter
<img width="186" height="79" alt="Screenshot 2025-10-10 at 14 42 56" src="https://github.com/user-attachments/assets/c6dedf53-3c49-4cf1-8ed7-b2676bb6fb32" />
<img width="186"  alt="Screenshot 2025-10-10 at 14 43 26" src="https://github.com/user-attachments/assets/49128429-fdb3-44d5-a725-828ae8da94ad" />

Auto-complete
<img width="240" height="84" alt="Screenshot 2025-10-10 at 14 51 30" src="https://github.com/user-attachments/assets/e40bb965-92c9-41bc-afc9-73b065800dca" />

<img width="240" alt="Screenshot 2025-10-10 at 14 50 37" src="https://github.com/user-attachments/assets/470bc582-0cd1-45ea-97d1-3bfd829bc4c6" />