### PR TITLE
Introduce plugin changelog, create separate DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,45 @@
+## Useful project gradle commands
+
+## Common
+
+### Verification
+
+- run all tests: `./gradlew test`
+
+- check code style: `./gradlew spotlessCheck`
+
+- check ABI: `./gradlew checkLegacyAbi`
+
+### Update
+
+- apply formatting: `./gradlew spotlessApply`
+
+- update ABI: `./gradlew updateLegacyAbi`
+
+### Info
+
+- create html test report: `./gradlew components:test:coverage:koverHtmlReport`
+
+- print test coverage: `./gradlew components:test:coverage:koverLog`
+
+## Plugin
+
+### Development
+
+Build plugin: `./gradlew buildPlugin`
+
+Run plugin in IDE sandbox: `./gradlew runIde`
+
+### Changelog
+
+Print current changelog: `./gradlew getChangelog`
+
+Update changelog with new version: `./gradlew patchChangelog`
+
+## CLI
+
+Build CLI: `./gradlew buildCLI`
+
+## WEB
+
+- Run WASM: `./gradlew tools:compose-app:wasmJsBrowserDevelopmentRun`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ needs.
 - [Other](#other)
   - [Export formats](#export-formats)
   - [Comparison with other solutions](#comparison-with-other-solutions)
-  - [Gradle commands](#gradle-commands)
   - [Migration guide](#migration-guide)
 
 ## Key features
@@ -586,26 +585,6 @@ get() {
 </td>
 </tr>
 </table>
-
-### Gradle commands
-
-other available gradle commands:
-
-- run tests: `./gradlew test`
-
-- check code style: `./gradlew spotlessCheck`
-
-- apply formatting: `./gradlew spotlessApply`
-
-- update ABI: `./gradlew updateLegacyAbi`
-
-- check ABI: `./gradlew checkLegacyAbi`
-
-- create html test report: `./gradlew components:test:coverage:koverHtmlReport`
-
-- print test coverage: `./gradlew components:test:coverage:koverLog`
-
-- WASM app: `./gradlew tools:compose-app:wasmJsBrowserDevelopmentRun`
 
 ### Migration guide
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kover) apply false
     alias(libs.plugins.jetbrains.compose) apply false
+    alias(libs.plugins.jetbrains.changelog) apply false
     alias(libs.plugins.jetbrains.intellij) apply false
     alias(libs.plugins.jetbrains.intellij.module) apply false
     alias(libs.plugins.buildConfig) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+jetbrains-changelog = "org.jetbrains.changelog:2.4.0"
 jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 jetbrains-intellij = { id = "org.jetbrains.intellij.platform", version.ref = "intellij" }
 jetbrains-intellij-module = { id = "org.jetbrains.intellij.platform.module", version.ref = "intellij" }

--- a/tools/idea-plugin/CHANGELOG.md
+++ b/tools/idea-plugin/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Plugin Changelog
+
+## [Unreleased]
+
+### Added
+
+- Setup of changelog plugin
+
+## [0.17.2](https://github.com/ComposeGears/Valkyrie/releases/tag/0.17.2) - 2025-10-11
+
+### Fixed
+
+- Handle aspect ratio for ImageVectorIcon rendering in gutter and auto-complete popup
+- Fix PSI parsing for material icon without materialIcon block, introduce BuilderExpression
+
+### Changed
+
+- Move :extensions into :sdk:core:extensions
+- Simplify navigation transitions across screens
+
+## [0.17.1](https://github.com/ComposeGears/Valkyrie/releases/tag/0.17.1) - 2025-10-09
+
+### Fixed
+
+- Fix PSI parsing when nullable KtProperty on top of file
+
+## [0.17.0](https://github.com/ComposeGears/Valkyrie/releases/tag/0.17.0) - 2025-10-09
+
+### Added
+
+- Image Vector Preview in Autocomplete Dialog
+- Image Vector Preview in Gutter
+- Add caching for icon creation in ImageVectorCompletionContributor
+- Introduce ImageVectorIcon for HQ preview in CompletionContributor
+- ImageVector to XML generator
+- Add Clip Path Support (KMP)
+- Add SDK core XML module to share VectorDrawable class
+
+### Changed
+
+- Gutter icon improvements
+- Optimize ImageVectorIcon rendering by removing scale dependency and introducing a constant for icon size
+- Refactor path utilities: move toPathString and toPathArgs to new PathNode
+
+## [0.16.0](https://github.com/ComposeGears/Valkyrie/releases/tag/0.16.0) - 2025-07-24
+
+### Changed
+
+- No notable changes
+
+## [0.15.0](https://github.com/ComposeGears/Valkyrie/releases/tag/0.15.0) - 2025-06-28
+
+### Added
+
+- Show export issues, add auto fix functionality
+- Allow numbers in icon pack names
+- Parse gradient startColor/endColor
+
+### Fixed
+
+- "useComposeColors" option not used in plugin
+- Fix ImageVector preview with linear gradient
+- "Auto resolve issues" cleared all processing icons
+- Export issues should consider nested pack duplicates
+
+## [0.14.0](https://github.com/ComposeGears/Valkyrie/releases/tag/0.14.0) - 2025-04-28
+
+### Added
+
+- [Export] Replace color hex with predefined Compose colors
+- [Preview] Handle predefined Compose colors during parsing
+
+### Fixed
+
+- [IconPack] Preview action crash if icon pasted from clipboard
+- Fix plugin not dynamic due to missing id
+
+## [0.13.0](https://github.com/ComposeGears/Valkyrie/releases/tag/0.13.0) - 2025-03-08
+
+### Added
+
+- Introduce separate Preview annotation for AndroidX and Jetbrains package

--- a/tools/idea-plugin/build.gradle.kts
+++ b/tools/idea-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -6,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.valkyrie.compose)
     alias(libs.plugins.jetbrains.intellij)
+    alias(libs.plugins.jetbrains.changelog)
 }
 
 group = rootProject.providers.gradleProperty("GROUP").get()
@@ -57,9 +59,12 @@ compose.resources {
 intellijPlatform {
     buildSearchableOptions = false
     projectName = "valkyrie-plugin"
-    pluginConfiguration.ideaVersion {
-        sinceBuild = "242"
-        untilBuild = provider { null }
+    pluginConfiguration {
+        ideaVersion {
+            sinceBuild = "242"
+            untilBuild = provider { null }
+        }
+        changeNotes = provider { changelog.render(Changelog.OutputType.HTML) }
     }
     pluginVerification {
         failureLevel = listOf(
@@ -105,6 +110,12 @@ kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.JVM_21
     }
+}
+
+changelog {
+    groups.empty()
+    repositoryUrl = "https://github.com/ComposeGears/Valkyrie"
+    versionPrefix = ""
 }
 
 tasks {

--- a/tools/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/tools/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -82,4 +82,3 @@ Allows to create organized icon pack with an extension property of you pack obje
     </extensions>
 
 </idea-plugin>
-


### PR DESCRIPTION
- closes: #195 

<img width="1094" height="1087" alt="Screenshot 2025-10-13 at 12 32 26" src="https://github.com/user-attachments/assets/71bfeb9c-2aee-4d44-946d-262b05333e07" />
