### PR TITLE
Fix executable permissions for the 'valkyrie' binary in CLI distribution

### DIFF
--- a/tools/cli/build.gradle.kts
+++ b/tools/cli/build.gradle.kts
@@ -77,7 +77,13 @@ val buildWithR8 by tasks.registering(JavaExec::class) {
 val buildCLI by tasks.registering(Zip::class) {
     dependsOn(buildWithR8)
 
-    from(layout.buildDirectory.file("install/valkyrie-shadow"))
+    from(layout.buildDirectory.file("install/valkyrie-shadow")) {
+        filesMatching("bin/valkyrie") {
+            permissions {
+                unix("rwxr-xr-x") // 755 in octal
+            }
+        }
+    }
 
     archiveFileName.set("$baseName-cli-$version.zip")
     destinationDirectory.set(layout.buildDirectory.dir("distributions/"))


### PR DESCRIPTION
- closes: #640 


<img width="900" height="138" alt="Screenshot 2025-10-13 at 17 36 15" src="https://github.com/user-attachments/assets/b5093ed5-0e7c-4a36-b1ac-15298d7a8b3b" />
