### PR TITLE
Don't override maxParallelForks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,5 @@ allprojects {
 
     tasks.withType<Test>().configureEach {
         useJUnitPlatform()
-        // https://docs.gradle.org/8.9/userguide/performance.html#execute_tests_in_parallel
-        maxParallelForks = Runtime.getRuntime().availableProcessors()
     }
 }


### PR DESCRIPTION
May slow down the tests. Let's view the result after removing this.