### PR TITLE
Fix description text truncation on main screen

### DIFF
--- a/compose/ui/src/commonMain/kotlin/io/github/composegears/valkyrie/compose/ui/InfoCard.kt
+++ b/compose/ui/src/commonMain/kotlin/io/github/composegears/valkyrie/compose/ui/InfoCard.kt
@@ -70,7 +70,7 @@ fun InfoCard(
                     text = description,
                     style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
                     color = LocalContentColor.current.dim(),
-                    maxLines = 1,
+                    maxLines = 2,
                 )
             }
         }

--- a/tools/idea-plugin/CHANGELOG.md
+++ b/tools/idea-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add a new mode for backward conversion from ImageVector to XML
 
+### Fixed
+
+- Fix main screen description text being cut off or truncated
+
 ### Changed
 
 - Drop support for IntelliJ IDEA 2024.2


### PR DESCRIPTION
<img width="400" alt="Screenshot 2025-11-21 at 16 49 02" src="https://github.com/user-attachments/assets/8f748212-f67b-4254-814f-4248180b5e6c" />
