### PR TITLE
[Gradle] Introduce separate code style configuration for generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,15 @@ valkyrie {
   // Optional: Generate flat package structure without subfolders (default: false)
   useFlatPackage = false
 
+  // Optional: Code style configuration for generated code
+  codeStyle {
+    // Add explicit `public` modifier to generated declarations (default: false)
+    useExplicitMode = false
+
+    // Number of spaces used for each level of indentation in generated code (default: 4)
+    indentSize = 4
+  }
+
   // Optional: ImageVector generation configuration
   imageVector {
     // Output format for generated ImageVectors (default: BackingProperty)
@@ -426,14 +435,8 @@ valkyrie {
     // Specifies the type of Preview annotation to generate for @Preview
     previewAnnotationType = PreviewAnnotationType.AndroidX
 
-    // Add explicit `public` modifier to generated declarations (default: false)
-    useExplicitMode = false
-
     // Insert a trailing comma after the last element of ImageVector.Builder block and path params (default: false)
     addTrailingComma = false
-
-    // Number of spaces used for each level of indentation in generated code (default: 4)
-    indentSize = 4
   }
 
   // Optional: Custom output directory (default: build/generated/sources/valkyrie)

--- a/tools/gradle-plugin/api/gradle-plugin.api
+++ b/tools/gradle-plugin/api/gradle-plugin.api
@@ -1,16 +1,21 @@
+public abstract class io/github/composegears/valkyrie/gradle/CodeStyleConfigExtension {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getIndentSize ()Lorg/gradle/api/provider/Property;
+	public final fun getUseExplicitMode ()Lorg/gradle/api/provider/Property;
+}
+
 public abstract class io/github/composegears/valkyrie/gradle/ImageVectorConfigExtension {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public final fun getAddTrailingComma ()Lorg/gradle/api/provider/Property;
 	public final fun getGeneratePreview ()Lorg/gradle/api/provider/Property;
-	public final fun getIndentSize ()Lorg/gradle/api/provider/Property;
 	public final fun getOutputFormat ()Lorg/gradle/api/provider/Property;
 	public final fun getPreviewAnnotationType ()Lorg/gradle/api/provider/Property;
 	public final fun getUseComposeColors ()Lorg/gradle/api/provider/Property;
-	public final fun getUseExplicitMode ()Lorg/gradle/api/provider/Property;
 }
 
 public abstract class io/github/composegears/valkyrie/gradle/ValkyrieExtension {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun codeStyle (Lkotlin/jvm/functions/Function1;)V
 	public final fun getGenerateAtSync ()Lorg/gradle/api/provider/Property;
 	public final fun getIconPackName ()Lorg/gradle/api/provider/Property;
 	public final fun getNestedPackName ()Lorg/gradle/api/provider/Property;

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/CodeStyleConfigExtension.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/CodeStyleConfigExtension.kt
@@ -1,0 +1,26 @@
+package io.github.composegears.valkyrie.gradle
+
+import io.github.composegears.valkyrie.gradle.dsl.property
+import javax.inject.Inject
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+
+abstract class CodeStyleConfigExtension @Inject constructor(objects: ObjectFactory) {
+    /**
+     * Add explicit `public` modifier to generated declarations.
+     *
+     * Default: `false`
+     */
+    val useExplicitMode: Property<Boolean> = objects
+        .property<Boolean>()
+        .convention(false)
+
+    /**
+     * Number of spaces used for each level of indentation in generated code.
+     *
+     * Default: `4`
+     */
+    val indentSize: Property<Int> = objects
+        .property<Int>()
+        .convention(4)
+}

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ImageVectorConfigExtension.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ImageVectorConfigExtension.kt
@@ -55,15 +55,6 @@ abstract class ImageVectorConfigExtension @Inject constructor(objects: ObjectFac
         .convention(PreviewAnnotationType.AndroidX)
 
     /**
-     * Add explicit `public` modifier to generated declarations.
-     *
-     * Default: `false`
-     */
-    val useExplicitMode: Property<Boolean> = objects
-        .property<Boolean>()
-        .convention(false)
-
-    /**
      * Insert a trailing comma after the last element of ImageVector.Builder block and path params.
      *
      * Default: `false`
@@ -71,13 +62,4 @@ abstract class ImageVectorConfigExtension @Inject constructor(objects: ObjectFac
     val addTrailingComma: Property<Boolean> = objects
         .property<Boolean>()
         .convention(false)
-
-    /**
-     * Number of spaces used for each level of indentation in generated code.
-     *
-     * Default: `4`
-     */
-    val indentSize: Property<Int> = objects
-        .property<Int>()
-        .convention(4)
 }

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieExtension.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieExtension.kt
@@ -70,6 +70,19 @@ abstract class ValkyrieExtension @Inject constructor(objects: ObjectFactory) {
         .convention(false)
 
     /**
+     * Code style configuration for generated code.
+     */
+    @get:Nested
+    internal val codeStyle: CodeStyleConfigExtension = objects.newInstance<CodeStyleConfigExtension>()
+
+    /**
+     * Configures code style options for generated code
+     */
+    @Suppress("unused")
+    @Configuring
+    fun codeStyle(action: CodeStyleConfigExtension.() -> Unit) = action.invoke(codeStyle)
+
+    /**
      * ImageVector generation configuration.
      */
     @get:Nested

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/internal/Utils.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/internal/Utils.kt
@@ -37,9 +37,9 @@ internal fun registerTask(
         task.generatePreview.convention(extension.imageVector.generatePreview)
         task.previewAnnotationType.convention(extension.imageVector.previewAnnotationType)
         task.useFlatPackage.convention(extension.useFlatPackage)
-        task.useExplicitMode.convention(extension.imageVector.useExplicitMode)
+        task.useExplicitMode.convention(extension.codeStyle.useExplicitMode)
         task.addTrailingComma.convention(extension.imageVector.addTrailingComma)
-        task.indentSize.convention(extension.imageVector.indentSize)
+        task.indentSize.convention(extension.codeStyle.indentSize)
     }
 }
 

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/NoPackPluginConfigurationTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/NoPackPluginConfigurationTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.contains
 import assertk.assertions.containsMatch
 import assertk.assertions.exists
 import assertk.assertions.isEqualTo
+import io.github.composegears.valkyrie.gradle.common.CommonGradleTest
 import io.github.composegears.valkyrie.gradle.common.GENERATED_SOURCES_DIR
 import io.github.composegears.valkyrie.gradle.internal.TASK_NAME
 import java.nio.file.Path

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieGradlePluginTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieGradlePluginTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
 import assertk.assertions.exists
+import io.github.composegears.valkyrie.gradle.common.CommonGradleTest
 import io.github.composegears.valkyrie.gradle.common.doesNotExist
 import io.github.composegears.valkyrie.gradle.internal.TASK_NAME
 import java.nio.file.Path
@@ -156,14 +157,17 @@ class ValkyrieGradlePluginTest : CommonGradleTest() {
                     nestedPackName = "MyNestedPack"
                     useFlatPackage = true
 
+                    codeStyle {
+                        useExplicitMode = true
+                        indentSize = 8
+                    }
+
                     imageVector {
                         outputFormat = OutputFormat.LazyProperty
                         useComposeColors = false
                         generatePreview = true
                         previewAnnotationType = PreviewAnnotationType.Jetbrains
-                        useExplicitMode = true
                         addTrailingComma = true
-                        indentSize = 8
                     }
                 }
             """.trimIndent(),

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/common/CommonGradleTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/common/CommonGradleTest.kt
@@ -1,8 +1,12 @@
-package io.github.composegears.valkyrie.gradle
+package io.github.composegears.valkyrie.gradle.common
 
 import assertk.Assert
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import io.github.composegears.valkyrie.gradle.ANDROID_HOME
+import io.github.composegears.valkyrie.gradle.GRADLE_VERSION
+import io.github.composegears.valkyrie.gradle.RESOURCES_DIR_SVG
+import io.github.composegears.valkyrie.gradle.RESOURCES_DIR_XML
 import io.github.composegears.valkyrie.gradle.internal.DEFAULT_RESOURCE_DIRECTORY
 import java.nio.file.Path
 import java.nio.file.Paths


### PR DESCRIPTION
Separate `codeStyle` option that will be shared between `imagevector` and `iconpack` generation

```kotlin
valkyrie {
  codeStyle {
    useExplicitMode = false
    indentSize = 4
  }
}
```

- ref: #738 