### PR TITLE
[Gradle] Refactor path resolution for generated Kotlin sources, update package names in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,8 +694,8 @@ the generated files after the generation task.
 val copyTask = tasks.register<Copy>("copyValkyrieIcons") {
   dependsOn(tasks.named("generateValkyrieImageVector"))
 
-  from(layout.buildDirectory.dir("generated/sources/valkyrie/commonMain"))
-  into(layout.projectDirectory.dir("src/commonMain/kotlin"))
+  from(layout.buildDirectory.dir("generated/sources/valkyrie"))
+  into(layout.projectDirectory.dir("src"))
 }
 
 val cleanTask = tasks.register<Delete>("cleanValkyrieGenerated") {

--- a/tools/gradle-plugin/CHANGELOG.md
+++ b/tools/gradle-plugin/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Automatically handle full qualified imports for icons that conflict with reserved Compose qualified names (`Brush`,
   `Color`, `Offset`)
 
+### Changed
+
+- Generated files are now placed in a `kotlin` subdirectory within each source set output directory (e.g.,
+  `build/generated/valkyrie/{sourceSetName}/kotlin` instead of `build/generated/valkyrie/{sourceSetName}`)
+
 ## [0.2.0] - 2025-12-08
 
 ### Added

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/internal/TaskRegistry.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/internal/TaskRegistry.kt
@@ -31,7 +31,7 @@ internal fun registerTask(
         task.packageName.convention(extension.packageName)
 
         val outputRoot = extension.outputDirectory
-        val perSourceSetDir = outputRoot.map { it.dir(sourceSet.name) }
+        val perSourceSetDir = outputRoot.map { it.dir("${sourceSet.name}/kotlin") }
         task.outputDirectory.convention(perSourceSetDir)
         sourceSet.kotlin.srcDir(perSourceSetDir)
 

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/FullQualifiedNamesTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/FullQualifiedNamesTest.kt
@@ -5,7 +5,6 @@ import assertk.assertions.contains
 import assertk.assertions.doesNotContain
 import assertk.assertions.exists
 import io.github.composegears.valkyrie.gradle.common.CommonGradleTest
-import io.github.composegears.valkyrie.gradle.common.GENERATED_SOURCES_DIR
 import io.github.composegears.valkyrie.gradle.internal.TASK_NAME
 import java.nio.file.Path
 import kotlin.io.path.copyTo
@@ -28,7 +27,7 @@ class FullQualifiedNamesTest : CommonGradleTest() {
                     id("io.github.composegears.valkyrie")
                 }
                 valkyrie {
-                    packageName = "test.icons"
+                    packageName = "x.y.z"
                 }
                 kotlin {
                     jvm()
@@ -45,7 +44,7 @@ class FullQualifiedNamesTest : CommonGradleTest() {
 
         assertThat(result.output).contains("Found icons names that conflict with reserved Compose qualifiers. Full qualified import will be used for: \"Brush\"")
 
-        val ktPath = root.resolve("${GENERATED_SOURCES_DIR}/commonMain/test/icons/Brush.kt")
+        val ktPath = root.resolveGeneratedPath("commonMain", "x/y/z/Brush.kt")
         assertThat(ktPath).exists()
         assertThat(ktPath.readText()).doesNotContain("import androidx.compose.ui.graphics.Brush")
     }
@@ -61,7 +60,7 @@ class FullQualifiedNamesTest : CommonGradleTest() {
                     id("io.github.composegears.valkyrie")
                 }
                 valkyrie {
-                    packageName = "test.icons"
+                    packageName = "x.y.z"
                 }
                 kotlin {
                     jvm()
@@ -78,7 +77,7 @@ class FullQualifiedNamesTest : CommonGradleTest() {
 
         assertThat(result.output).contains("Found icons names that conflict with reserved Compose qualifiers. Full qualified import will be used for: \"Color\"")
 
-        val ktPath = root.resolve("${GENERATED_SOURCES_DIR}/commonMain/test/icons/Color.kt")
+        val ktPath = root.resolveGeneratedPath("commonMain", "x/y/z/Color.kt")
         assertThat(ktPath).exists()
         assertThat(ktPath.readText()).doesNotContain("import androidx.compose.ui.graphics.Color")
     }
@@ -94,7 +93,7 @@ class FullQualifiedNamesTest : CommonGradleTest() {
                     id("io.github.composegears.valkyrie")
                 }
                 valkyrie {
-                    packageName = "test.icons"
+                    packageName = "x.y.z"
                 }
                 kotlin {
                     jvm()
@@ -111,7 +110,7 @@ class FullQualifiedNamesTest : CommonGradleTest() {
 
         assertThat(result.output).contains("Found icons names that conflict with reserved Compose qualifiers. Full qualified import will be used for: \"Offset\"")
 
-        val ktPath = root.resolve("${GENERATED_SOURCES_DIR}/commonMain/test/icons/Offset.kt")
+        val ktPath = root.resolveGeneratedPath("commonMain", "x/y/z/Offset.kt")
         assertThat(ktPath).exists()
         assertThat(ktPath.readText()).doesNotContain("import androidx.compose.ui.graphics.Offset")
     }

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/NoPackPluginConfigurationTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/NoPackPluginConfigurationTest.kt
@@ -9,7 +9,6 @@ import io.github.composegears.valkyrie.gradle.common.GENERATED_SOURCES_DIR
 import io.github.composegears.valkyrie.gradle.internal.TASK_NAME
 import java.nio.file.Path
 import kotlin.io.path.readText
-import kotlin.io.path.walk
 import kotlin.io.path.writeText
 import org.gradle.testkit.runner.TaskOutcome.SKIPPED
 import org.junit.jupiter.api.Test
@@ -46,12 +45,12 @@ class NoPackPluginConfigurationTest : CommonGradleTest() {
         assertThat(result).taskWasSuccessful(":$TASK_NAME")
         assertThat(result.output).contains("Generated 17 ImageVector icons in package \"x.y.z\"")
 
-        val generatedIcons = root.resolve(GENERATED_SOURCES_DIR).walk().toList()
-        assertThat(generatedIcons.count()).isEqualTo(17)
+        val generatedIcons = root.allGeneratedFiles()
+        assertThat(generatedIcons.size).isEqualTo(17)
 
         generatedIcons.forEach { file ->
             val relativePath = root.resolve(GENERATED_SOURCES_DIR).relativize(file)
-            assertThat(relativePath.toString()).contains("commonMain/x/y/z/")
+            assertThat(relativePath.toString()).contains("commonMain/kotlin/x/y/z/")
 
             assertThat(file.readText()).containsMatch(Regex("val [A-Za-z0-9_]+: ImageVector"))
         }

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/SimplePackPluginConfigurationTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/SimplePackPluginConfigurationTest.kt
@@ -10,7 +10,6 @@ import io.github.composegears.valkyrie.gradle.common.GENERATED_SOURCES_DIR
 import io.github.composegears.valkyrie.gradle.internal.TASK_NAME
 import java.nio.file.Path
 import kotlin.io.path.readText
-import kotlin.io.path.walk
 import kotlin.io.path.writeText
 import org.gradle.testkit.runner.TaskOutcome.SKIPPED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -52,10 +51,9 @@ class SimplePackPluginConfigurationTest : CommonGradleTest() {
         assertThat(result.output).contains("No icon files to process for ImageVector generation")
 
         val iconPackName = "ValkyrieIcons"
-        assertThat(root.resolve("${GENERATED_SOURCES_DIR}/commonMain/x/y/z/$iconPackName.kt")).exists()
+        assertThat(root.resolveGeneratedPath("commonMain", "x/y/z/$iconPackName.kt")).exists()
 
-        val generatedFiles = root.resolve(GENERATED_SOURCES_DIR).walk().toList()
-        assertThat(generatedFiles.count()).isEqualTo(1)
+        assertThat(root.allGeneratedFiles().size).isEqualTo(1)
     }
 
     @Test
@@ -91,10 +89,9 @@ class SimplePackPluginConfigurationTest : CommonGradleTest() {
         assertThat(result.output).contains("No icon files to process for ImageVector generation")
 
         val iconPackName = "ValkyrieIcons"
-        assertThat(root.resolve("${GENERATED_SOURCES_DIR}/jvmMain/x/y/z/$iconPackName.kt")).exists()
+        assertThat(root.resolveGeneratedPath("jvmMain", "x/y/z/$iconPackName.kt")).exists()
 
-        val generatedFiles = root.resolve(GENERATED_SOURCES_DIR).walk().toList()
-        assertThat(generatedFiles.count()).isEqualTo(1)
+        assertThat(root.allGeneratedFiles().size).isEqualTo(1)
     }
 
     @Test
@@ -133,16 +130,16 @@ class SimplePackPluginConfigurationTest : CommonGradleTest() {
         assertThat(result.output).contains("Generated 17 ImageVector icons in package \"x.y.z\"")
 
         val iconPackName = "ValkyrieIcons"
-        assertThat(root.resolve("${GENERATED_SOURCES_DIR}/commonMain/x/y/z/$iconPackName.kt")).exists()
+        assertThat(root.resolveGeneratedPath("commonMain", "x/y/z/$iconPackName.kt")).exists()
 
-        val generatedFiles = root.resolve(GENERATED_SOURCES_DIR).walk().toList()
+        val generatedFiles = root.allGeneratedFiles()
+        assertThat(generatedFiles.size).isEqualTo(18)
 
-        assertThat(generatedFiles.count()).isEqualTo(18)
         generatedFiles
             .filter { it.fileName.toString() != "$iconPackName.kt" }
             .forEach { file ->
                 val relativePath = root.resolve(GENERATED_SOURCES_DIR).relativize(file)
-                assertThat(relativePath.toString()).contains("commonMain/x/y/z/")
+                assertThat(relativePath.toString()).contains("commonMain/kotlin/x/y/z/")
 
                 assertThat(file.readText()).containsMatch("val $iconPackName.[A-Za-z0-9_]+: ImageVector".toRegex())
             }

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieGradlePluginTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieGradlePluginTest.kt
@@ -104,7 +104,7 @@ class ValkyrieGradlePluginTest : CommonGradleTest() {
             "ClipPathGradient.kt",
             "LinearGradientWithStroke.kt",
         ).forEach { filename ->
-            assertThat(root.resolve("build/generated/sources/valkyrie/main/x/y/z/$filename")).exists()
+            assertThat(root.resolveGeneratedPath("main", "x/y/z/$filename")).exists()
         }
     }
 
@@ -150,7 +150,7 @@ class ValkyrieGradlePluginTest : CommonGradleTest() {
             "ClipPathGradient.kt",
             "LinearGradientWithStroke.kt",
         ).forEach { filename ->
-            assertThat(root.resolve("build/generated/sources/valkyrie/main/x/y/z/$filename")).exists()
+            assertThat(root.resolveGeneratedPath("main", "x/y/z/$filename")).exists()
         }
 
         // and the LinearGradient file is created with the right visibility, parent pack, nested pack, etc
@@ -233,7 +233,7 @@ class ValkyrieGradlePluginTest : CommonGradleTest() {
             "SeveralPath.kt",
             "AllPathParams.kt",
         ).forEach { filename ->
-            assertThat(root.resolve("build/generated/sources/valkyrie/main/x/y/z/$filename")).exists()
+            assertThat(root.resolveGeneratedPath("main", "x/y/z/$filename")).exists()
         }
     }
 
@@ -308,14 +308,14 @@ class ValkyrieGradlePluginTest : CommonGradleTest() {
 
         // and files were generated in the right source sets
         listOf(
-            "build/generated/sources/valkyrie/freeRelease/x/y/z/LinearGradient.kt",
-            "build/generated/sources/valkyrie/freeRelease/x/y/z/RadialGradient.kt",
-            "build/generated/sources/valkyrie/freeRelease/x/y/z/ClipPathGradient.kt",
-            "build/generated/sources/valkyrie/freeRelease/x/y/z/LinearGradientWithStroke.kt",
-            "build/generated/sources/valkyrie/debug/x/y/z/OnlyPath.kt",
-            "build/generated/sources/valkyrie/debug/x/y/z/IconWithShorthandColor.kt",
-            "build/generated/sources/valkyrie/debug/x/y/z/SeveralPath.kt",
-            "build/generated/sources/valkyrie/debug/x/y/z/AllPathParams.kt",
+            "build/generated/sources/valkyrie/freeRelease/kotlin/x/y/z/LinearGradient.kt",
+            "build/generated/sources/valkyrie/freeRelease/kotlin/x/y/z/RadialGradient.kt",
+            "build/generated/sources/valkyrie/freeRelease/kotlin/x/y/z/ClipPathGradient.kt",
+            "build/generated/sources/valkyrie/freeRelease/kotlin/x/y/z/LinearGradientWithStroke.kt",
+            "build/generated/sources/valkyrie/debug/kotlin/x/y/z/OnlyPath.kt",
+            "build/generated/sources/valkyrie/debug/kotlin/x/y/z/IconWithShorthandColor.kt",
+            "build/generated/sources/valkyrie/debug/kotlin/x/y/z/SeveralPath.kt",
+            "build/generated/sources/valkyrie/debug/kotlin/x/y/z/AllPathParams.kt",
         ).forEach { path ->
             assertThat(root.resolve(path)).exists()
         }
@@ -377,7 +377,7 @@ class ValkyrieGradlePluginTest : CommonGradleTest() {
             "ClipPathGradient.kt",
             "LinearGradientWithStroke.kt",
         ).forEach { filename ->
-            assertThat(root.resolve("build/generated/sources/valkyrie/main/com/example/app/$filename")).exists()
+            assertThat(root.resolveGeneratedPath("main", "com/example/app/$filename")).exists()
         }
 
         // and the compilation succeeded, so the accessor code has access to the generated code dirs
@@ -543,7 +543,7 @@ class ValkyrieGradlePluginTest : CommonGradleTest() {
             "ClipPathGradient.kt",
             "LinearGradientWithStroke.kt",
         ).forEach { filename ->
-            assertThat(root.resolve("build/generated/sources/valkyrie/main/x/y/z/$filename")).exists()
+            assertThat(root.resolveGeneratedPath("main", "x/y/z/$filename")).exists()
         }
     }
 

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/common/CommonGradleTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/common/CommonGradleTest.kt
@@ -14,6 +14,8 @@ import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.copyToRecursively
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.walk
 import kotlin.io.path.writeText
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
@@ -21,6 +23,16 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 open class CommonGradleTest {
+
+    protected fun Path.resolveGeneratedPath(sourceSet: String, packagePath: String): Path {
+        return resolve("$GENERATED_SOURCES_DIR/$sourceSet/kotlin/$packagePath")
+    }
+
+    protected fun Path.allGeneratedFiles(): List<Path> = resolve(GENERATED_SOURCES_DIR)
+        .walk()
+        .filter { it.isRegularFile() }
+        .toList()
+
     protected fun buildRunner(root: Path): GradleRunner = GradleRunner
         .create()
         .withPluginClasspath()


### PR DESCRIPTION
- closes: #753

added `kotlin` folder

<img width="449" height="384" alt="image" src="https://github.com/user-attachments/assets/fd9d7bad-114e-4fba-88af-80f2fffba788" />
