### PR TITLE
[Gradle] Add autoMirror configuration support for ImageVectors at multiple levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,13 @@ valkyrie {
   // Optional: Generate during IDE sync for better developer experience (default: false)
   generateAtSync = false
 
+  // Optional: Force all generated ImageVectors to have a specific autoMirror value (default: not specified)
+  // When set to true, all icons will have autoMirror = true
+  // When set to false, all icons will have autoMirror = false
+  // When not specified, the autoMirror value from the original icon file will be preserved
+  // This can be overridden at the icon pack or nested pack level
+  autoMirror = false
+
   // Optional: Code style configuration for generated code
   codeStyle {
     // Add explicit `public` modifier to generated declarations (default: false)
@@ -454,6 +461,11 @@ valkyrie {
     // Optional: Generate flat package structure without subfolders (default: false)
     useFlatPackage = false
 
+    // Optional: Force all ImageVectors in this icon pack to have a specific autoMirror value (default: not specified)
+    // When set, overrides the root level autoMirror setting
+    // This can be overridden at the nested pack level
+    autoMirror = true
+
     // Optional: Nested icon packs configuration
     nested {
       // Required: Name of the nested icon pack object
@@ -461,6 +473,10 @@ valkyrie {
 
       // Required: The source folder path containing icons for this nested pack, relative to the `resourceDirectoryName`.
       sourceFolder = "outlined"
+
+      // Optional: Force all ImageVectors in this nested pack to have a specific autoMirror value (default: not specified)
+      // When set, overrides the icon pack level and root level autoMirror settings
+      autoMirror = false
     }
     // You can add more nested packs if necessary
   }
@@ -707,6 +723,50 @@ tasks.register("updateValkyrieIcons") {
   finalizedBy(cleanTask)
 }
 ```
+
+#### AutoMirror configuration
+
+The `autoMirror` parameter controls whether icons should automatically flip horizontally when used in right-to-left (
+RTL) layouts. This is particularly useful for directional icons like arrows, chevrons, or navigation elements.
+
+**Configuration hierarchy:**
+
+The plugin supports a three-level hierarchy for `autoMirror` configuration:
+
+1. **Root level** - applies to all icons across the project
+2. **Icon pack level** - overrides root level for all icons in the pack
+3. **Nested pack level** - overrides both icon pack and root level for icons in the nested pack
+
+For example, to force enable RTL support for icons in the `Navigation` nested pack:
+
+```kotlin
+valkyrie {
+  packageName = "com.example.app.icons"
+
+  iconPack {
+    name = "ValkyrieIcons"
+    targetSourceSet = "commonMain"
+
+    nested {
+      name = "Navigation"
+      sourceFolder = "navigation"
+
+      autoMirror = true
+    }
+
+    nested {
+      name = "Logos"
+      sourceFolder = "logos"
+    }
+  }
+}
+```
+
+In this example:
+
+- Icons in the `Navigation` nested pack will have `autoMirror = true`
+- Icons in the `Logos` nested pack (and any other nested pack without an explicit `autoMirror` setting) will preserve
+  the original `autoMirror` value from the source icon file
 
 ## Other
 

--- a/tools/gradle-plugin/CHANGELOG.md
+++ b/tools/gradle-plugin/CHANGELOG.md
@@ -6,6 +6,50 @@
 
 - Automatically handle full qualified imports for icons that conflict with reserved Compose qualified names (`Brush`,
   `Color`, `Offset`)
+- Add `autoMirror` configuration support at root, icon pack, and nested pack levels to control RTL (right-to-left) 
+  layout behavior for generated ImageVectors
+
+The `autoMirror` parameter controls whether icons should automatically flip horizontally when used in RTL layouts.
+This is particularly useful for directional icons like arrows, chevrons, or navigation elements.
+
+Configuration can be set at three levels with override hierarchy:
+1. **Root level** - applies to all icons across the project
+2. **Icon pack level** - overrides root level for all icons in the pack
+3. **Nested pack level** - overrides both icon pack and root level for icons in the nested pack
+
+Example configuration:
+
+```kotlin
+valkyrie {
+  packageName = "com.example.app.icons"
+  
+  // Force all icons to support RTL by default
+  autoMirror = true
+
+  iconPack {
+    name = "ValkyrieIcons"
+    targetSourceSet = "commonMain"
+    
+    // Override: icons in this pack won't auto-mirror
+    autoMirror = false
+
+    nested {
+      name = "Navigation"
+      sourceFolder = "navigation"
+      // Override: navigation icons should auto-mirror for RTL
+      autoMirror = true
+    }
+
+    nested {
+      name = "Logos"
+      sourceFolder = "logos"
+      // Logos inherit autoMirror = false from icon pack level
+    }
+  }
+}
+```
+
+When `autoMirror` is not specified at any level, the original value from the source icon file will be preserved.
 
 ### Changed
 

--- a/tools/gradle-plugin/api/gradle-plugin.api
+++ b/tools/gradle-plugin/api/gradle-plugin.api
@@ -6,6 +6,7 @@ public abstract class io/github/composegears/valkyrie/gradle/CodeStyleConfigExte
 
 public abstract class io/github/composegears/valkyrie/gradle/IconPackExtension {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getAutoMirror ()Lorg/gradle/api/provider/Property;
 	public final fun getName ()Lorg/gradle/api/provider/Property;
 	public final fun getTargetSourceSet ()Lorg/gradle/api/provider/Property;
 	public final fun getUseFlatPackage ()Lorg/gradle/api/provider/Property;
@@ -23,6 +24,7 @@ public abstract class io/github/composegears/valkyrie/gradle/ImageVectorConfigEx
 
 public abstract class io/github/composegears/valkyrie/gradle/NestedPack {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getAutoMirror ()Lorg/gradle/api/provider/Property;
 	public final fun getName ()Lorg/gradle/api/provider/Property;
 	public final fun getSourceFolder ()Lorg/gradle/api/provider/Property;
 }
@@ -30,6 +32,7 @@ public abstract class io/github/composegears/valkyrie/gradle/NestedPack {
 public abstract class io/github/composegears/valkyrie/gradle/ValkyrieExtension {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public final fun codeStyle (Lkotlin/jvm/functions/Function1;)V
+	public final fun getAutoMirror ()Lorg/gradle/api/provider/Property;
 	public final fun getGenerateAtSync ()Lorg/gradle/api/provider/Property;
 	public final fun getOutputDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getPackageName ()Lorg/gradle/api/provider/Property;

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/IconPackExtension.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/IconPackExtension.kt
@@ -9,6 +9,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 import org.gradle.declarative.dsl.model.annotations.Configuring
 
 abstract class IconPackExtension @Inject constructor(
@@ -39,6 +40,21 @@ abstract class IconPackExtension @Inject constructor(
     val useFlatPackage: Property<Boolean> = objects
         .property<Boolean>()
         .convention(false)
+
+    /**
+     * Force all ImageVectors in this icon pack to have a specific autoMirror value.
+     *
+     * When set to `true`, all icons in this pack will have `autoMirror = true`.
+     * When set to `false`, all icons in this pack will have `autoMirror = false`.
+     * When not specified, the autoMirror value from the root extension or the original icon file will be used.
+     *
+     * This can be overridden at the nested pack level.
+     *
+     * Default: not specified
+     */
+    @get:Input
+    @get:Optional
+    val autoMirror: Property<Boolean> = objects.property<Boolean>()
 
     @get:Nested
     internal val nestedPacks: ListProperty<NestedPack> = objects
@@ -92,4 +108,17 @@ abstract class NestedPack @Inject constructor(objects: ObjectFactory) {
      */
     @get:Input
     val sourceFolder: Property<String> = objects.property<String>()
+
+    /**
+     * Force all ImageVectors in this nested pack to have a specific autoMirror value.
+     *
+     * When set to `true`, all icons in this nested pack will have `autoMirror = true`.
+     * When set to `false`, all icons in this nested pack will have `autoMirror = false`.
+     * When not specified, the autoMirror value from the icon pack or root extension will be used.
+     *
+     * Default: not specified
+     */
+    @get:Input
+    @get:Optional
+    val autoMirror: Property<Boolean> = objects.property<Boolean>()
 }

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieExtension.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/ValkyrieExtension.kt
@@ -58,6 +58,20 @@ abstract class ValkyrieExtension @Inject constructor(private val objects: Object
         .convention(DEFAULT_RESOURCE_DIRECTORY)
 
     /**
+     * Force all generated ImageVectors to have a specific autoMirror value.
+     *
+     * When set to `true`, all icons will have `autoMirror = true`.
+     * When set to `false`, all icons will have `autoMirror = false`.
+     * When not specified, the autoMirror value from the original icon file will be preserved.
+     *
+     * This can be overridden at the icon pack or nested pack level.
+     *
+     * Default: not specified
+     */
+    @get:Optional
+    val autoMirror: Property<Boolean> = objects.property<Boolean>()
+
+    /**
      * Code style configuration for generated code.
      */
     @get:Nested

--- a/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/internal/TaskRegistry.kt
+++ b/tools/gradle-plugin/src/main/kotlin/io/github/composegears/valkyrie/gradle/internal/TaskRegistry.kt
@@ -42,6 +42,7 @@ internal fun registerTask(
         task.useExplicitMode.convention(extension.codeStyle.useExplicitMode)
         task.addTrailingComma.convention(extension.imageVector.addTrailingComma)
         task.indentSize.convention(extension.codeStyle.indentSize)
+        task.autoMirror.convention(extension.autoMirror)
 
         task.sourceSet.convention(sourceSet.name)
         task.iconPack.convention(extension.iconPack)

--- a/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/AutoMirrorConfigurationTest.kt
+++ b/tools/gradle-plugin/src/test/kotlin/io/github/composegears/valkyrie/gradle/AutoMirrorConfigurationTest.kt
@@ -1,0 +1,417 @@
+package io.github.composegears.valkyrie.gradle
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.exists
+import assertk.assertions.isEqualTo
+import io.github.composegears.valkyrie.gradle.common.CommonGradleTest
+import io.github.composegears.valkyrie.gradle.internal.TASK_NAME
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import kotlin.io.path.walk
+import kotlin.io.path.writeText
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class AutoMirrorConfigurationTest : CommonGradleTest() {
+
+    @Test
+    fun `autoMirror true at root level affects all icons`(@TempDir root: Path) {
+        root.writeSettingsFile()
+
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    kotlin("multiplatform")
+                    id("io.github.composegears.valkyrie")
+                }
+                valkyrie {
+                    packageName = "x.y.z"
+                    autoMirror = true
+                }
+                kotlin {
+                    jvm()
+                }
+            """.trimIndent(),
+        )
+
+        root.writeTestDrawables(sourceSet = "commonMain")
+
+        val result = runTask(root, TASK_NAME)
+
+        assertThat(result).taskWasSuccessful(":$TASK_NAME")
+        assertThat(result.output).contains("Generated 17 ImageVector icons in package \"x.y.z\"")
+
+        val generatedFiles = root.allGeneratedFiles()
+        assertThat(generatedFiles.size).isEqualTo(17)
+
+        // Verify all icons have autoMirror = true
+        generatedFiles.forEach { file ->
+            assertThat(file.readText()).contains("autoMirror = true")
+        }
+    }
+
+    @Test
+    fun `autoMirror false at root level affects all icons`(@TempDir root: Path) {
+        root.writeSettingsFile()
+
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    kotlin("multiplatform")
+                    id("io.github.composegears.valkyrie")
+                }
+                valkyrie {
+                    packageName = "x.y.z"
+                    autoMirror = false
+                }
+                kotlin {
+                    jvm()
+                }
+            """.trimIndent(),
+        )
+
+        root.writeTestDrawables(sourceSet = "commonMain")
+
+        val result = runTask(root, TASK_NAME)
+
+        assertThat(result).taskWasSuccessful(":$TASK_NAME")
+        assertThat(result.output).contains("Generated 17 ImageVector icons in package \"x.y.z\"")
+
+        val generatedFiles = root.allGeneratedFiles()
+        assertThat(generatedFiles.size).isEqualTo(17)
+
+        // Verify all icons don't have autoMirror
+        generatedFiles.forEach { file ->
+            assertThat(file.readText()).doesNotContain("autoMirror")
+        }
+    }
+
+    @Test
+    fun `autoMirror at iconPack level overrides root level`(@TempDir root: Path) {
+        root.writeSettingsFile()
+
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    kotlin("multiplatform")
+                    id("io.github.composegears.valkyrie")
+                }
+                valkyrie {
+                    packageName = "x.y.z"
+                    autoMirror = false
+
+                    iconPack {
+                        name = "ValkyrieIcons"
+                        targetSourceSet = "commonMain"
+                        autoMirror = true
+                    }
+                }
+                kotlin {
+                    jvm()
+                }
+            """.trimIndent(),
+        )
+
+        root.writeTestDrawables(sourceSet = "commonMain")
+
+        val result = runTask(root, TASK_NAME)
+
+        assertThat(result).taskWasSuccessful(":$TASK_NAME")
+        assertThat(result.output).contains("Generated \"ValkyrieIcons\" iconpack in package \"x.y.z\"")
+        assertThat(result.output).contains("Generated 17 ImageVector icons in package \"x.y.z\"")
+
+        val iconPackName = "ValkyrieIcons"
+        assertThat(root.resolveGeneratedPath("commonMain", "x/y/z/$iconPackName.kt")).exists()
+
+        val generatedFiles = root.allGeneratedFiles()
+        assertThat(generatedFiles.size).isEqualTo(18)
+
+        // Verify all icons have autoMirror = true (iconPack level overrides root)
+        generatedFiles
+            .filter { it.fileName.toString() != "$iconPackName.kt" }
+            .forEach { file ->
+                assertThat(file.readText()).contains("autoMirror = true")
+            }
+    }
+
+    @Test
+    fun `autoMirror at nested pack level overrides iconPack level`(@TempDir root: Path) {
+        root.writeSettingsFile()
+
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    kotlin("multiplatform")
+                    id("io.github.composegears.valkyrie")
+                }
+                valkyrie {
+                    packageName = "x.y.z"
+                    autoMirror = false
+
+                    iconPack {
+                        name = "ValkyrieIcons"
+                        targetSourceSet = "commonMain"
+                        autoMirror = true
+
+                        nested {
+                            name = "Outlined"
+                            sourceFolder = "outlined"
+                            autoMirror = false
+                        }
+
+                        nested {
+                            name = "Filled"
+                            sourceFolder = "filled"
+                        }
+                    }
+                }
+                kotlin {
+                    jvm()
+                }
+            """.trimIndent(),
+        )
+
+        root.writeNestedPackDrawables(sourceSet = "commonMain")
+
+        val result = runTask(root, TASK_NAME)
+
+        assertThat(result).taskWasSuccessful(":$TASK_NAME")
+        assertThat(result.output).contains("Generated \"ValkyrieIcons\" iconpack in package \"x.y.z\"")
+
+        val iconPackName = "ValkyrieIcons"
+        assertThat(root.resolveGeneratedPath("commonMain", "x/y/z/$iconPackName.kt")).exists()
+
+        // Check Outlined nested pack icons have autoMirror = false
+        val outlinedFiles = root.resolveGeneratedPath("commonMain", "x/y/z/outlined").walk().toList()
+        outlinedFiles.forEach { file ->
+            assertThat(file.readText()).doesNotContain("autoMirror")
+        }
+
+        // Check Filled nested pack icons have autoMirror = true (from iconPack level)
+        val filledFiles = root.resolveGeneratedPath("commonMain", "x/y/z/filled").walk().toList()
+        filledFiles.forEach { file ->
+            val content = file.readText()
+            assertThat(content).contains("autoMirror = true")
+        }
+    }
+
+    @Test
+    fun `no autoMirror configuration preserves original values`(@TempDir root: Path) {
+        root.writeSettingsFile()
+
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    kotlin("multiplatform")
+                    id("io.github.composegears.valkyrie")
+                }
+                valkyrie {
+                    packageName = "x.y.z"
+                }
+                kotlin {
+                    jvm()
+                }
+            """.trimIndent(),
+        )
+
+        root.writeTestDrawables(sourceSet = "commonMain")
+
+        val result = runTask(root, TASK_NAME)
+
+        assertThat(result).taskWasSuccessful(":$TASK_NAME")
+        assertThat(result.output).contains("Generated 17 ImageVector icons in package \"x.y.z\"")
+
+        val generatedFiles = root.allGeneratedFiles()
+        assertThat(generatedFiles.size).isEqualTo(17)
+
+        // All test drawables shouldn't have autoMirror (from the source files)
+        generatedFiles.forEach { file ->
+            if (file.name == "AllPathParams.kt") {
+                assertThat(file.readText()).contains("autoMirror = true")
+            } else {
+                assertThat(file.readText()).doesNotContain("autoMirror")
+            }
+        }
+    }
+
+    @Test
+    fun `autoMirror in nested pack without iconPack level configuration`(@TempDir root: Path) {
+        root.writeSettingsFile()
+
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    kotlin("multiplatform")
+                    id("io.github.composegears.valkyrie")
+                }
+                valkyrie {
+                    packageName = "x.y.z"
+
+                    iconPack {
+                        name = "ValkyrieIcons"
+                        targetSourceSet = "commonMain"
+
+                        nested {
+                            name = "Outlined"
+                            sourceFolder = "outlined"
+                            autoMirror = true
+                        }
+
+                        nested {
+                            name = "Filled"
+                            sourceFolder = "filled"
+                            autoMirror = false
+                        }
+                    }
+                }
+                kotlin {
+                    jvm()
+                }
+            """.trimIndent(),
+        )
+
+        root.writeNestedPackDrawables(sourceSet = "commonMain")
+
+        val result = runTask(root, TASK_NAME)
+
+        assertThat(result).taskWasSuccessful(":$TASK_NAME")
+        assertThat(result.output).contains("Generated \"ValkyrieIcons\" iconpack in package \"x.y.z\"")
+
+        // Check Outlined nested pack icons have autoMirror = true
+        val outlinedFiles = root.resolveGeneratedPath("commonMain", "x/y/z/outlined").walk().toList()
+        outlinedFiles.forEach { file ->
+            assertThat(file.readText()).contains("autoMirror = true")
+        }
+
+        // Check Filled nested pack icons don't have autoMirror
+        val filledFiles = root.resolveGeneratedPath("commonMain", "x/y/z/filled").walk().toList()
+        filledFiles.forEach { file ->
+            assertThat(file.readText()).doesNotContain("autoMirror")
+        }
+    }
+
+    @Test
+    fun `autoMirror at root level with nested pack`(@TempDir root: Path) {
+        root.writeSettingsFile()
+
+        root.resolve("build.gradle.kts").writeText(
+            """
+                plugins {
+                    kotlin("multiplatform")
+                    id("io.github.composegears.valkyrie")
+                }
+                valkyrie {
+                    packageName = "x.y.z"
+                    autoMirror = true
+
+                    iconPack {
+                        name = "ValkyrieIcons"
+                        targetSourceSet = "commonMain"
+
+                        nested {
+                            name = "Outlined"
+                            sourceFolder = "outlined"
+                        }
+                        nested {
+                            name = "Filled"
+                            sourceFolder = "filled"
+                        }
+                    }
+                }
+                kotlin {
+                    jvm()
+                }
+            """.trimIndent(),
+        )
+
+        root.writeNestedPackDrawables(sourceSet = "commonMain")
+
+        val result = runTask(root, TASK_NAME)
+
+        assertThat(result).taskWasSuccessful(":$TASK_NAME")
+        assertThat(result.output).contains("Generated \"ValkyrieIcons\" iconpack in package \"x.y.z\"")
+
+        // Check Outlined nested pack icons have autoMirror = true
+        val outlinedFiles = root.resolveGeneratedPath("commonMain", "x/y/z/outlined").walk().toList()
+        outlinedFiles.forEach { file ->
+            assertThat(file.readText()).contains("autoMirror = true")
+        }
+
+        // Check Filled nested pack icons have autoMirror = true
+        val filledFiles = root.resolveGeneratedPath("commonMain", "x/y/z/filled").walk().toList()
+        filledFiles.forEach { file ->
+            assertThat(file.readText()).contains("autoMirror = true")
+        }
+    }
+
+    private fun Path.writeNestedPackDrawables(sourceSet: String) {
+        val resourceDir = resolve("src/$sourceSet/valkyrieResources")
+        val outlinedDir = resourceDir.resolve("outlined")
+        val filledDir = resourceDir.resolve("filled")
+
+        outlinedDir.createDirectories()
+        filledDir.createDirectories()
+
+        // Write some test XML drawables for outlined
+        outlinedDir.resolve("outlined_icon1.xml").writeText(
+            """
+            <vector xmlns:android="http://schemas.android.com/apk/res/android"
+                android:width="24dp"
+                android:height="24dp"
+                android:viewportWidth="24"
+                android:viewportHeight="24">
+                <path
+                    android:fillColor="#FF000000"
+                    android:pathData="M12,2L2,7v10c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12L20,7l-10,-5z"/>
+            </vector>
+            """.trimIndent(),
+        )
+
+        outlinedDir.resolve("outlined_icon2.xml").writeText(
+            """
+            <vector xmlns:android="http://schemas.android.com/apk/res/android"
+                android:width="24dp"
+                android:height="24dp"
+                android:viewportWidth="24"
+                android:viewportHeight="24">
+                <path
+                    android:fillColor="#FF000000"
+                    android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z"/>
+            </vector>
+            """.trimIndent(),
+        )
+
+        // Write some test XML drawables for filled
+        filledDir.resolve("filled_icon1.xml").writeText(
+            """
+            <vector xmlns:android="http://schemas.android.com/apk/res/android"
+                android:width="24dp"
+                android:height="24dp"
+                android:viewportWidth="24"
+                android:viewportHeight="24">
+                <path
+                    android:fillColor="#FF000000"
+                    android:pathData="M19,3L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2z"/>
+            </vector>
+            """.trimIndent(),
+        )
+
+        filledDir.resolve("filled_icon2.xml").writeText(
+            """
+            <vector xmlns:android="http://schemas.android.com/apk/res/android"
+                android:width="24dp"
+                android:height="24dp"
+                android:viewportWidth="24"
+                android:viewportHeight="24">
+                <path
+                    android:fillColor="#FF000000"
+                    android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+            </vector>
+            """.trimIndent(),
+        )
+    }
+}


### PR DESCRIPTION
- closes: #754 


Add `autoMirror` configuration support at root, icon pack, and nested pack levels to control RTL (right-to-left) 
  layout behavior for generated ImageVectors

The `autoMirror` parameter controls whether icons should automatically flip horizontally when used in RTL layouts.
This is particularly useful for directional icons like arrows, chevrons, or navigation elements.

Configuration can be set at three levels with override hierarchy:
1. **Root level** - applies to all icons across the project
2. **Icon pack level** - overrides root level for all icons in the pack
3. **Nested pack level** - overrides both icon pack and root level for icons in the nested pack

Example configuration:

```kotlin
valkyrie {
  packageName = "com.example.app.icons"
  
  // Force all icons to support RTL by default
  autoMirror = true

  iconPack {
    name = "ValkyrieIcons"
    targetSourceSet = "commonMain"
    
    // Override: icons in this pack won't auto-mirror
    autoMirror = false

    nested {
      name = "Navigation"
      sourceFolder = "navigation"
      // Override: navigation icons should auto-mirror for RTL
      autoMirror = true
    }

    nested {
      name = "Logos"
      sourceFolder = "logos"
      // Logos inherit autoMirror = false from icon pack level
    }
  }
}
```

When `autoMirror` is not specified at any level, the original value from the source icon file will be preserved.
