### PR TITLE
[IDEA Plugin] Make icon previews in the ProjectView configurable

### DIFF
--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/icon/ImageVectorIconProvider.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/icon/ImageVectorIconProvider.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.IconProvider
 import com.intellij.openapi.project.DumbAware
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import io.github.composegears.valkyrie.service.PersistentSettings.Companion.persistentSettings
 import io.github.composegears.valkyrie.util.getOrCreateCachedIcon
 import io.github.composegears.valkyrie.util.hasImageVectorProperties
 import javax.swing.Icon
@@ -20,7 +21,11 @@ class ImageVectorIconProvider :
             else -> element.containingFile as? KtFile
         } ?: return null
 
-        if (!ktFile.hasImageVectorProperties()) {
+        val project = element.project
+        if (project.isDisposed) return null
+        val showIconsInProjectView = project.persistentSettings.state.showIconsInProjectView
+
+        if (!showIconsInProjectView || !ktFile.hasImageVectorProperties()) {
             return null
         }
 

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/service/PersistentSettings.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/service/PersistentSettings.kt
@@ -48,6 +48,7 @@ class PersistentSettings : SimplePersistentStateComponent<ValkyrieState>(Valkyri
         var addTrailingComma: Boolean by property(false)
 
         var showImageVectorPreview: Boolean by property(true)
+        var showIconsInProjectView: Boolean by property(true)
         var indentSize: Int by property(4)
     }
 

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/settings/InMemorySettings.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/settings/InMemorySettings.kt
@@ -54,6 +54,7 @@ class InMemorySettings(project: Project) {
         useExplicitMode = false
         addTrailingComma = false
         showImageVectorPreview = true
+        showIconsInProjectView = true
         indentSize = 4
     }
 
@@ -68,25 +69,26 @@ class InMemorySettings(project: Project) {
             useMaterialPack = useMaterialPack,
 
             packageName = packageName.or("io.github.composegears.valkyrie"),
-            iconPackPackage = iconPackPackage.or(packageName.or("io.github.composegears.valkyrie")),
             iconPackName = iconPackName.or("ValkyrieIcons"),
+            iconPackPackage = iconPackPackage.or(packageName.or("io.github.composegears.valkyrie")),
             iconPackDestination = iconPackDestination.or(""),
 
             nestedPacks = nestedPacks.orEmpty()
                 .split(",")
                 .filter { it.isNotEmpty() },
 
-            outputFormat = OutputFormat.from(outputFormat),
-
             generatePreview = generatePreview,
             previewAnnotationType = PreviewAnnotationType.from(previewAnnotationType),
 
-            flatPackage = flatPackage,
+            outputFormat = OutputFormat.from(outputFormat),
             useComposeColors = useComposeColors,
+            indentSize = indentSize,
+            flatPackage = flatPackage,
             useExplicitMode = useExplicitMode,
             addTrailingComma = addTrailingComma,
-            indentSize = indentSize,
+
             showImageVectorPreview = showImageVectorPreview,
+            showIconsInProjectView = showIconsInProjectView,
         )
     }
 }
@@ -114,6 +116,7 @@ data class ValkyriesSettings(
     val addTrailingComma: Boolean,
 
     val showImageVectorPreview: Boolean,
+    val showIconsInProjectView: Boolean,
 )
 
 fun PersistentSettings.ValkyrieState.updateNestedPack(packs: List<String>) {

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/SettingsViewModel.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/SettingsViewModel.kt
@@ -15,6 +15,7 @@ import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateAddTrailingComma
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateExplicitMode
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateFlatPackage
+import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateIconsInProjectView
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateImageVectorPreview
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateIndentSize
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateOutputFormat
@@ -52,6 +53,7 @@ class SettingsViewModel : ViewModel() {
         PreviewSettings(
             previewType = it.previewType,
             showImageVectorPreview = it.showImageVectorPreview,
+            showIconsInProjectView = it.showIconsInProjectView,
         )
     }
 
@@ -61,6 +63,7 @@ class SettingsViewModel : ViewModel() {
             is UpdateUseComposeColors -> useComposeColors = settingsAction.useComposeColor
             is UpdateOutputFormat -> updateOutputFormat(settingsAction.outputFormat)
             is UpdateImageVectorPreview -> showImageVectorPreview = settingsAction.enabled
+            is UpdateIconsInProjectView -> showIconsInProjectView = settingsAction.enabled
             is UpdateFlatPackage -> flatPackage = settingsAction.useFlatPackage
             is UpdateExplicitMode -> useExplicitMode = settingsAction.useExplicitMode
             is UpdateAddTrailingComma -> addTrailingComma = settingsAction.addTrailingComma
@@ -96,5 +99,6 @@ data class GeneralSettings(
 
 data class PreviewSettings(
     val showImageVectorPreview: Boolean,
+    val showIconsInProjectView: Boolean,
     val previewType: PreviewType,
 )

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/model/SettingsAction.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/model/SettingsAction.kt
@@ -15,5 +15,6 @@ sealed interface SettingsAction {
     data class UpdateIndentSize(val indent: Int) : SettingsAction
 
     data class UpdateImageVectorPreview(val enabled: Boolean) : SettingsAction
+    data class UpdateIconsInProjectView(val enabled: Boolean) : SettingsAction
     data class UpdatePreviewType(val previewType: PreviewType) : SettingsAction
 }

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/preview/ImageVectorPreviewSettingsScreen.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/settings/tabs/preview/ImageVectorPreviewSettingsScreen.kt
@@ -29,6 +29,7 @@ import io.github.composegears.valkyrie.ui.foundation.theme.PreviewTheme
 import io.github.composegears.valkyrie.ui.screen.settings.PreviewSettings
 import io.github.composegears.valkyrie.ui.screen.settings.SettingsViewModel
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction
+import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateIconsInProjectView
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdateImageVectorPreview
 import io.github.composegears.valkyrie.ui.screen.settings.model.SettingsAction.UpdatePreviewType
 
@@ -76,6 +77,32 @@ private fun ImageVectorPreviewSettingsUi(
                 )
             },
         )
+        ListItem(
+            modifier = Modifier
+                .toggleable(
+                    value = previewSettings.showIconsInProjectView,
+                    onValueChange = { onAction(UpdateIconsInProjectView(it)) },
+                )
+                .padding(horizontal = 8.dp)
+                .heightIn(max = 100.dp),
+            headlineContent = {
+                Text(text = "Show icons in Project View")
+            },
+            supportingContent = {
+                Text(
+                    text = "Display ImageVector preview as file icons in the project tree. \nTo ensure the icon cache updates fully, it's recommended to restart the IDE.",
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                    color = LocalContentColor.current.dim(),
+                )
+            },
+            trailingContent = {
+                Switch(
+                    modifier = Modifier.scale(0.9f),
+                    checked = previewSettings.showIconsInProjectView,
+                    onCheckedChange = { onAction(UpdateIconsInProjectView(it)) },
+                )
+            },
+        )
         VerticalSpacer(16.dp)
         PreviewBgSection(
             previewType = previewSettings.previewType,
@@ -90,6 +117,7 @@ private fun ImageVectorPreviewSettingsPreview() = PreviewTheme(alignment = Align
     ImageVectorPreviewSettingsUi(
         previewSettings = PreviewSettings(
             showImageVectorPreview = true,
+            showIconsInProjectView = true,
             previewType = PreviewType.Auto,
         ),
         onAction = {},

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/util/ImageVectorPsiUtil.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/util/ImageVectorPsiUtil.kt
@@ -34,17 +34,16 @@ fun KtFile.hasImageVectorProperties(): Boolean {
 }
 
 /**
-* Gets or creates a cached icon for a Kotlin file containing an ImageVector.
-*
-* Uses the PSI caching mechanism to avoid recreating the icon repeatedly
-* for the same file, improving performance.
-*/
+ * Gets or creates a cached icon for a Kotlin file containing an ImageVector.
+ *
+ * Uses the PSI caching mechanism to avoid recreating the icon repeatedly
+ * for the same file, improving performance.
+ */
 fun KtFile.getOrCreateCachedIcon(): Icon? {
-    return CachedValuesManager
-        .getManager(project).getCachedValue(this) {
-            val icon = createImageVectorIcon()
-            CachedValueProvider.Result.create(icon, this)
-        }
+    return CachedValuesManager.getCachedValue(this) {
+        val icon = createImageVectorIcon()
+        CachedValueProvider.Result.create(icon, this)
+    }
 }
 
 /**
@@ -54,9 +53,7 @@ fun KtFile.getOrCreateCachedIcon(): Icon? {
  * for the same property, improving performance.
  */
 fun KtProperty.getOrCreateGutterIcon(): Icon? {
-    val cachedValuesManager = CachedValuesManager.getManager(project)
-
-    return cachedValuesManager.getCachedValue(this) {
+    return CachedValuesManager.getCachedValue(this) {
         val icon = createIcon()
 
         CachedValueProvider.Result.create(icon, this)

--- a/tools/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/tools/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -69,7 +69,7 @@ Allows to create organized icon pack with an extension property of you pack obje
 
         <codeInsight.lineMarkerProvider
             language="kotlin"
-            implementationClass="io.github.composegears.valkyrie.gutter.ImageVectorGutterProvider" />
+            implementationClass="io.github.composegears.valkyrie.gutter.ImageVectorGutterProvider"/>
 
         <completion.contributor
             language="kotlin"


### PR DESCRIPTION
- closes: #771

Disabled:
<img width="1512" height="1067" alt="Screenshot 2025-12-12 at 15 33 42" src="https://github.com/user-attachments/assets/8c89a176-49c2-4743-b867-7dd8a3050977" />

Enabled:
<img width="1512" height="1067" alt="Screenshot 2025-12-12 at 15 33 54" src="https://github.com/user-attachments/assets/f00f2bd5-6bce-416c-9803-26520e9b3584" />
