### PR TITLE
[IDEA] Simplify gutter tooltip text generation for ImageVector icons

### DIFF
--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/gutter/ImageVectorGutterProvider.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/gutter/ImageVectorGutterProvider.kt
@@ -69,20 +69,24 @@ class ImageVectorGutterProvider : LineMarkerProvider {
         icon: Icon,
         name: String,
         navigationTarget: T?,
-    ): LineMarkerInfo<T> = LineMarkerInfo(
-        element,
-        element.textRange,
-        icon,
-        { "ImageVector Icon: $name" },
-        { _, _ ->
-            navigationTarget?.createSmartPointer()?.let { target ->
-                target.element
-                    ?.let(EditSourceUtil::getDescriptor)
-                    ?.takeIf(Navigatable::canNavigate)
-                    ?.navigate(true)
-            }
-        },
-        GutterIconRenderer.Alignment.LEFT,
-        { "ImageVector Icon: $name" },
-    )
+    ): LineMarkerInfo<T> {
+        val tooltipName = name.takeIf { it.isNotBlank() } ?: "ImageVector Icon"
+
+        return LineMarkerInfo(
+            element,
+            element.textRange,
+            icon,
+            { tooltipName },
+            { _, _ ->
+                navigationTarget?.createSmartPointer()?.let { target ->
+                    target.element
+                        ?.let(EditSourceUtil::getDescriptor)
+                        ?.takeIf(Navigatable::canNavigate)
+                        ?.navigate(true)
+                }
+            },
+            GutterIconRenderer.Alignment.LEFT,
+            { tooltipName },
+        )
+    }
 }


### PR DESCRIPTION
make tooltip text shorter

<img width="588" height="423" alt="Screenshot 2026-01-01 at 14 00 58" src="https://github.com/user-attachments/assets/b3814956-fac0-46e1-80f8-451ac3a9e9c1" />
