### PR TITLE
Fix PSI parsing for materialIcon with regular path calls

### DIFF
--- a/sdk/intellij/psi/imagevector/src/main/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/ImageVectorPsiParser.kt
+++ b/sdk/intellij/psi/imagevector/src/main/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/ImageVectorPsiParser.kt
@@ -22,7 +22,7 @@ object ImageVectorPsiParser {
             val fqName = it.importedFqName
 
             fqName?.asString() == "androidx.compose.material.icons.materialPath" ||
-                fqName?.asString() == "androidx.compose.material.icons.materialFilled"
+                fqName?.asString() == "androidx.compose.material.icons.materialIcon"
         }
     }
 }

--- a/sdk/intellij/psi/imagevector/src/main/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/common/PathParser.kt
+++ b/sdk/intellij/psi/imagevector/src/main/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/common/PathParser.kt
@@ -1,0 +1,23 @@
+package io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common
+
+import io.github.composegears.valkyrie.sdk.ir.core.IrVectorNode
+import org.jetbrains.kotlin.psi.KtCallExpression
+
+internal fun KtCallExpression.parsePathNode(): IrVectorNode.IrPath {
+    val pathLambda = lambdaArguments.firstOrNull()?.getLambdaExpression()
+    val pathBody = pathLambda?.bodyExpression
+
+    return IrVectorNode.IrPath(
+        name = parseStringArg("name").orEmpty(),
+        fill = parseFill(),
+        fillAlpha = parseFloatArg("fillAlpha") ?: 1f,
+        stroke = parseStroke(),
+        strokeAlpha = parseFloatArg("strokeAlpha") ?: 1f,
+        strokeLineWidth = parseFloatArg("strokeLineWidth") ?: 0f,
+        strokeLineCap = extractStrokeCap(),
+        strokeLineJoin = extractStrokeJoin(),
+        strokeLineMiter = parseFloatArg("strokeLineMiter") ?: 4f,
+        pathFillType = extractPathFillType(),
+        paths = pathBody?.parsePath().orEmpty(),
+    )
+}

--- a/sdk/intellij/psi/imagevector/src/main/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/parser/MaterialImageVectorPsiParser.kt
+++ b/sdk/intellij/psi/imagevector/src/main/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/parser/MaterialImageVectorPsiParser.kt
@@ -9,6 +9,7 @@ import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.mater
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.name
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parseFloatArg
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parsePath
+import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parsePathNode
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.viewportHeight
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.viewportWidth
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.util.childrenOfType
@@ -61,8 +62,9 @@ internal object MaterialImageVectorPsiParser {
 
     private fun KtBlockExpression.parseMaterialPath(): List<IrVectorNode> {
         val materialPathCalls = materialPathCalls()
+        val pathCalls = pathCalls()
 
-        return materialPathCalls.mapNotNull { materialPathCall ->
+        val materialPaths = materialPathCalls.mapNotNull { materialPathCall ->
             val pathLambda = materialPathCall.lambdaArguments.firstOrNull()?.getLambdaExpression()
             val pathBody = pathLambda?.bodyExpression ?: return@mapNotNull null
 
@@ -77,11 +79,23 @@ internal object MaterialImageVectorPsiParser {
                 paths = pathBody.parsePath(),
             )
         }
+
+        val regularPaths = pathCalls.map { pathCall ->
+            pathCall.parsePathNode()
+        }
+
+        return materialPaths + regularPaths
     }
 }
 
 private fun KtBlockExpression.materialPathCalls(): List<KtCallExpression> {
     return childrenOfType<KtCallExpression>().filter {
         it.calleeExpression?.text == "materialPath"
+    }
+}
+
+private fun KtBlockExpression.pathCalls(): List<KtCallExpression> {
+    return childrenOfType<KtCallExpression>().filter {
+        it.calleeExpression?.text == "path"
     }
 }

--- a/sdk/intellij/psi/imagevector/src/main/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/parser/RegularImageVectorPsiParser.kt
+++ b/sdk/intellij/psi/imagevector/src/main/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/parser/RegularImageVectorPsiParser.kt
@@ -11,8 +11,8 @@ import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.name
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parseClipPath
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parseFill
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parseFloatArg
-import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parsePath
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parsePathDataArg
+import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parsePathNode
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parseStringArg
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.parseStroke
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.common.viewportHeight
@@ -71,7 +71,7 @@ internal object RegularImageVectorPsiParser {
     private fun KtCallExpression.parseVectorNode(): IrVectorNode? {
         var node: IrVectorNode? = null
         if (calleeExpression?.text == "path") {
-            node = parsePath()
+            node = parsePathNode()
         }
         if (calleeExpression?.text == "addPath") {
             node = parseAddPath()
@@ -101,25 +101,6 @@ internal object RegularImageVectorPsiParser {
                 ?.mapNotNull { it.parseVectorNode() }
                 .orEmpty()
                 .toMutableList(),
-        )
-    }
-
-    private fun KtCallExpression.parsePath(): IrVectorNode.IrPath {
-        val pathLambda = lambdaArguments.firstOrNull()?.getLambdaExpression()
-        val pathBody = pathLambda?.bodyExpression
-
-        return IrVectorNode.IrPath(
-            name = parseStringArg("name").orEmpty(),
-            fill = parseFill(),
-            fillAlpha = parseFloatArg("fillAlpha") ?: 1f,
-            stroke = parseStroke(),
-            strokeAlpha = parseFloatArg("strokeAlpha") ?: 1f,
-            strokeLineWidth = parseFloatArg("strokeLineWidth") ?: 0f,
-            strokeLineCap = extractStrokeCap(),
-            strokeLineJoin = extractStrokeJoin(),
-            strokeLineMiter = parseFloatArg("strokeLineMiter") ?: 4f,
-            pathFillType = extractPathFillType(),
-            paths = pathBody?.parsePath().orEmpty(),
         )
     }
 

--- a/sdk/intellij/psi/imagevector/src/test/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/MaterialIconParserTest.kt
+++ b/sdk/intellij/psi/imagevector/src/test/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/MaterialIconParserTest.kt
@@ -7,6 +7,7 @@ import io.github.composegears.valkyrie.psi.TEST_DATA_PATH
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.expected.ExpectedIconWithImportMember
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.expected.ExpectedMaterialIcon
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.expected.ExpectedMaterialIconOnlyWithPath
+import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.expected.ExpectedMaterialIconWithPath
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.expected.ExpectedMaterialIconWithoutParam
 import io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.expected.ExpectedMaterialIconWithoutParam2
 import io.github.composegears.valkyrie.sdk.intellij.testfixtures.KotlinCodeInsightTest
@@ -53,6 +54,14 @@ class MaterialIconParserTest : KotlinCodeInsightTest() {
         val imageVector = ImageVectorPsiParser.parseToIrImageVector(ktFile)?.toComposeImageVector()
 
         assertThat(imageVector).isEqualTo(ExpectedIconWithImportMember)
+    }
+
+    @Test
+    fun `parse material icon with path`() = runInEdtAndGet {
+        val ktFile = loadKtFile("backing/MaterialIcon.path.kt")
+        val imageVector = ImageVectorPsiParser.parseToIrImageVector(ktFile)?.toComposeImageVector()
+
+        assertThat(imageVector).isEqualTo(ExpectedMaterialIconWithPath)
     }
 
     override fun getTestDataPath() = TEST_DATA_PATH

--- a/sdk/intellij/psi/imagevector/src/test/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/expected/MaterialIconWithPath.kt
+++ b/sdk/intellij/psi/imagevector/src/test/kotlin/io/github/composegears/valkyrie/sdk/intellij/psi/imagevector/expected/MaterialIconWithPath.kt
@@ -1,0 +1,25 @@
+package io.github.composegears.valkyrie.sdk.intellij.psi.imagevector.expected
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.path
+
+val ExpectedMaterialIconWithPath = materialIcon(name = "ArrowRight") {
+    path(
+        fill = SolidColor(Color.Black),
+        stroke = null,
+        strokeLineWidth = 1f,
+        strokeLineCap = StrokeCap.Butt,
+        strokeLineJoin = StrokeJoin.Bevel,
+        strokeLineMiter = 1f,
+    ) {
+        moveTo(10f, 17f)
+        lineTo(15f, 12f)
+        lineTo(10f, 7f)
+        verticalLineTo(17f)
+        close()
+    }
+}

--- a/sdk/intellij/psi/imagevector/src/test/resources/backing/MaterialIcon.path.kt
+++ b/sdk/intellij/psi/imagevector/src/test/resources/backing/MaterialIcon.path.kt
@@ -1,0 +1,38 @@
+package io.github.composegears.valkyrie
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+@Suppress("ObjectPropertyName")
+private var _arrowRight: ImageVector? = null
+
+val FinesIcons.ArrowRight: ImageVector
+    get() {
+        if (_arrowRight != null) return _arrowRight!!
+
+        _arrowRight = materialIcon(name = "ArrowRight") {
+            path(
+                fill = SolidColor(Color.Black),
+                stroke = null,
+                strokeLineWidth = 1f,
+                strokeLineCap = StrokeCap.Butt,
+                strokeLineJoin = StrokeJoin.Bevel,
+                strokeLineMiter = 1f,
+            ) {
+                moveTo(10f, 17f)
+                lineTo(15f, 12f)
+                lineTo(10f, 7f)
+                verticalLineTo(17f)
+                close()
+            }
+        }.build()
+
+        return _arrowRight!!
+    }

--- a/tools/idea-plugin/CHANGELOG.md
+++ b/tools/idea-plugin/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Remove support for `Material` icon pack from `androidx.compose.material.icons` package
 
+### Fixed
+
+- [PSI] Fix parsing `materialIcon` block with regular `path` calls
+
 ## 1.0.0 - 2026-02-10
 
 ### Added


### PR DESCRIPTION
---

- [ ] [CLI changelog](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md) "Unreleased" section has been updated, if applicable.
- [ ] [Gradle Plugin changelog](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md) "Unreleased" section has been updated, if applicable.
- [x] [IntelliJ Plugin changelog](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md) "Unreleased" section has been updated, if applicable.
