### PR TITLE
[WebImport] Update Icon Providers to use Woff2 from ttf

### DIFF
--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/lucide/data/LucideRepository.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/lucide/data/LucideRepository.kt
@@ -20,7 +20,7 @@ class LucideRepository(
 ) {
     companion object {
         private const val UNPKG_BASE = "https://unpkg.com/lucide-static@latest"
-        private const val FONT_URL = "$UNPKG_BASE/font/lucide.ttf"
+        private const val FONT_URL = "$UNPKG_BASE/font/lucide.woff2"
         private const val CSS_URL = "https://cdn.jsdelivr.net/npm/lucide-static@latest/font/lucide.css"
     }
 

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/material/domain/model/font/IconFontFamily.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/material/domain/model/font/IconFontFamily.kt
@@ -7,20 +7,20 @@ enum class IconFontFamily(
     val fontFamily: String,
 ) {
     OUTLINED(
-        githubUrl = "https://github.com/google/material-design-icons/raw/refs/heads/master/variablefont/MaterialSymbolsOutlined%5BFILL,GRAD,opsz,wght%5D.ttf",
-        cdnUrl = "https://cdn.jsdelivr.net/gh/google/material-design-icons@master/variablefont/MaterialSymbolsOutlined%5BFILL%2CGRAD%2Copsz%2Cwght%5D.ttf",
+        githubUrl = "https://github.com/google/material-design-icons/raw/refs/heads/master/variablefont/MaterialSymbolsOutlined%5BFILL,GRAD,opsz,wght%5D.woff2",
+        cdnUrl = "https://cdn.jsdelivr.net/gh/google/material-design-icons@master/variablefont/MaterialSymbolsOutlined%5BFILL%2CGRAD%2Copsz%2Cwght%5D.woff2",
         displayName = "Outlined",
         fontFamily = "materialsymbolsoutlined",
     ),
     ROUNDED(
-        githubUrl = "https://github.com/google/material-design-icons/raw/refs/heads/master/variablefont/MaterialSymbolsRounded%5BFILL,GRAD,opsz,wght%5D.ttf",
-        cdnUrl = "https://cdn.jsdelivr.net/gh/google/material-design-icons@master/variablefont/MaterialSymbolsRounded%5BFILL%2CGRAD%2Copsz%2Cwght%5D.ttf",
+        githubUrl = "https://github.com/google/material-design-icons/raw/refs/heads/master/variablefont/MaterialSymbolsRounded%5BFILL,GRAD,opsz,wght%5D.woff2",
+        cdnUrl = "https://cdn.jsdelivr.net/gh/google/material-design-icons@master/variablefont/MaterialSymbolsRounded%5BFILL%2CGRAD%2Copsz%2Cwght%5D.woff2",
         displayName = "Rounded",
         fontFamily = "materialsymbolsrounded",
     ),
     SHARP(
-        githubUrl = "https://github.com/google/material-design-icons/raw/refs/heads/master/variablefont/MaterialSymbolsSharp%5BFILL,GRAD,opsz,wght%5D.ttf",
-        cdnUrl = "https://cdn.jsdelivr.net/gh/google/material-design-icons@master/variablefont/MaterialSymbolsSharp%5BFILL%2CGRAD%2Copsz%2Cwght%5D.ttf",
+        githubUrl = "https://github.com/google/material-design-icons/raw/refs/heads/master/variablefont/MaterialSymbolsSharp%5BFILL,GRAD,opsz,wght%5D.woff2",
+        cdnUrl = "https://cdn.jsdelivr.net/gh/google/material-design-icons@master/variablefont/MaterialSymbolsSharp%5BFILL%2CGRAD%2Copsz%2Cwght%5D.woff2",
         displayName = "Sharp",
         fontFamily = "materialsymbolssharp",
     ),


### PR DESCRIPTION
---

- [ ] [CLI changelog](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md) "Unreleased" section has been updated, if applicable.
- [ ] [Gradle Plugin changelog](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md) "Unreleased" section has been updated, if applicable.
- [x] [IntelliJ Plugin changelog](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md) "Unreleased" section has been updated, if applicable.
