### PR TITLE
Exclude unused libraries from 'com.android.tools:sdk-common', reduce gradle-plugin size

### DIFF
--- a/build-logic/convention/src/main/kotlin/io/github/composegears/valkyrie/Excludes.kt
+++ b/build-logic/convention/src/main/kotlin/io/github/composegears/valkyrie/Excludes.kt
@@ -1,0 +1,23 @@
+package io.github.composegears.valkyrie
+
+import org.gradle.api.artifacts.Configuration
+import org.gradle.kotlin.dsl.exclude
+
+/**
+ * Exclude not used libraries from `com.android.tools:sdk-common:x.x.x` artifact
+ */
+fun Configuration.excludeAndroidBuildTools() {
+    exclude(group = "com.android.tools.analytics-library")
+    exclude(group = "com.android.tools.build", module = "aapt2-proto")
+    exclude(group = "com.android.tools.ddms")
+    exclude(group = "com.android.tools.layoutlib")
+    exclude(group = "com.android.tools", module = "sdklib")
+    exclude(group = "com.google.code.gson")
+    exclude(group = "com.google.guava")
+    exclude(group = "com.google.protobuf")
+    exclude(group = "org.apache.commons")
+    exclude(group = "org.bouncycastle")
+    exclude(group = "org.glassfish.jaxb")
+    exclude(group = "net.java.dev.jna")
+    exclude(group = "net.sf.kxml")
+}

--- a/tools/gradle-plugin/CHANGELOG.md
+++ b/tools/gradle-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add `usePathDataString` configuration option in `imageVector` block to generate addPath with pathData strings instead
   of path builder calls
 
+### Changed
+
+- Reduce gradle plugin size from 46mb to 10mb
+
 ### Removed
 
 - Remove support for `androidx.compose.desktop.ui.tooling.preview.Preview` and corresponding `previewAnnotationType`

--- a/tools/gradle-plugin/build.gradle.kts
+++ b/tools/gradle-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import io.github.composegears.valkyrie.excludeAndroidBuildTools
 import java.nio.file.Paths
 import java.util.Properties
 import kotlin.io.path.exists
@@ -87,6 +88,10 @@ val testPluginClasspath by configurations.registering {
 tasks.pluginUnderTestMetadata {
     // Plugins used in tests could be resolved in classpath.
     pluginClasspath.from(testPluginClasspath)
+}
+
+configurations.getByName("implementation") {
+    excludeAndroidBuildTools()
 }
 
 dependencies {

--- a/tools/idea-plugin/build.gradle.kts
+++ b/tools/idea-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import io.github.composegears.valkyrie.excludeAndroidBuildTools
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel
@@ -34,20 +35,7 @@ configurations.getByName("implementation") {
     exclude(group = "androidx.annotation")
     exclude(group = "androidx.lifecycle")
 
-    // Android Build Tools
-    exclude(group = "com.android.tools.analytics-library")
-    exclude(group = "com.android.tools.build", module = "aapt2-proto")
-    exclude(group = "com.android.tools.ddms")
-    exclude(group = "com.android.tools.layoutlib")
-    exclude(group = "com.android.tools", module = "sdklib")
-    exclude(group = "com.google.code.gson")
-    exclude(group = "com.google.guava")
-    exclude(group = "com.google.protobuf")
-    exclude(group = "org.apache.commons")
-    exclude(group = "org.bouncycastle")
-    exclude(group = "org.glassfish.jaxb")
-    exclude(group = "net.java.dev.jna")
-    exclude(group = "net.sf.kxml")
+    excludeAndroidBuildTools()
 }
 
 dependencies {


### PR DESCRIPTION

<img width="1614" height="154" alt="telegram-cloud-document-2-5251451487707502968" src="https://github.com/user-attachments/assets/12a9a05f-2590-442b-bd12-e1297c08ac2e" />


---

### 📝 Changelog

If this PR introduces user-facing changes, please update the relevant **Unreleased** section in changelogs:

- [ ] 🔌 [IntelliJ Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md)
- [ ] 🖥️ [CLI](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md)
- [x] 🐘 [Gradle Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md)
