### PR TITLE
Add preview for web import screens

### DIFF
--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/material/MaterialSymbolsImportScreen.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/material/MaterialSymbolsImportScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.font.FontVariation.grade
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
+import com.composegears.tiamat.compose.TiamatPreview
 import com.composegears.tiamat.compose.back
 import com.composegears.tiamat.compose.navController
 import com.composegears.tiamat.compose.navDestination
@@ -39,6 +40,7 @@ import io.github.composegears.valkyrie.jewel.BackAction
 import io.github.composegears.valkyrie.jewel.HorizontalDivider
 import io.github.composegears.valkyrie.jewel.Title
 import io.github.composegears.valkyrie.jewel.Toolbar
+import io.github.composegears.valkyrie.jewel.tooling.ProjectPreviewTheme
 import io.github.composegears.valkyrie.jewel.ui.placeholder.EmptyPlaceholder
 import io.github.composegears.valkyrie.jewel.ui.placeholder.ErrorPlaceholder
 import io.github.composegears.valkyrie.jewel.ui.placeholder.LoadingPlaceholder
@@ -64,6 +66,7 @@ import io.github.composegears.valkyrie.ui.screen.webimport.material.ui.MaterialF
 import io.github.composegears.valkyrie.ui.screen.webimport.material.ui.MaterialTopActions
 import io.github.composegears.valkyrie.util.stringResource
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
 
 val MaterialSymbolsImportScreen by navDestination {
@@ -343,3 +346,9 @@ private fun rememberMaterialSymbolsFont(
         FontVariation.opticalSizing(TextUnit(opticalSize, TextUnitType.Sp)),
     ),
 )
+
+@Preview
+@Composable
+private fun MaterialSymbolsImportScreenPreview() = ProjectPreviewTheme {
+    TiamatPreview(MaterialSymbolsImportScreen)
+}

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/standard/bootstrap/BootstrapImportScreen.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/standard/bootstrap/BootstrapImportScreen.kt
@@ -1,15 +1,19 @@
 package io.github.composegears.valkyrie.ui.screen.webimport.standard.bootstrap
 
+import androidx.compose.runtime.Composable
 import com.composegears.leviathan.compose.inject
+import com.composegears.tiamat.compose.TiamatPreview
 import com.composegears.tiamat.compose.back
 import com.composegears.tiamat.compose.navController
 import com.composegears.tiamat.compose.navDestination
 import com.composegears.tiamat.compose.navigate
+import io.github.composegears.valkyrie.jewel.tooling.ProjectPreviewTheme
 import io.github.composegears.valkyrie.ui.screen.mode.simple.conversion.SimpleConversionParamsSource.TextSource
 import io.github.composegears.valkyrie.ui.screen.mode.simple.conversion.SimpleConversionScreen
 import io.github.composegears.valkyrie.ui.screen.webimport.standard.bootstrap.di.BootstrapModule
 import io.github.composegears.valkyrie.ui.screen.webimport.standard.common.StandardImportScreen
 import io.github.composegears.valkyrie.util.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 val BootstrapImportScreen by navDestination {
     val navController = navController()
@@ -27,4 +31,10 @@ val BootstrapImportScreen by navDestination {
             )
         },
     )
+}
+
+@Preview
+@Composable
+private fun BootstrapImportScreenPreview() = ProjectPreviewTheme {
+    TiamatPreview(BootstrapImportScreen)
 }

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/standard/boxicons/BoxIconsImportScreen.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/standard/boxicons/BoxIconsImportScreen.kt
@@ -1,15 +1,19 @@
 package io.github.composegears.valkyrie.ui.screen.webimport.standard.boxicons
 
+import androidx.compose.runtime.Composable
 import com.composegears.leviathan.compose.inject
+import com.composegears.tiamat.compose.TiamatPreview
 import com.composegears.tiamat.compose.back
 import com.composegears.tiamat.compose.navController
 import com.composegears.tiamat.compose.navDestination
 import com.composegears.tiamat.compose.navigate
+import io.github.composegears.valkyrie.jewel.tooling.ProjectPreviewTheme
 import io.github.composegears.valkyrie.ui.screen.mode.simple.conversion.SimpleConversionParamsSource.TextSource
 import io.github.composegears.valkyrie.ui.screen.mode.simple.conversion.SimpleConversionScreen
 import io.github.composegears.valkyrie.ui.screen.webimport.standard.boxicons.di.BoxIconsModule
 import io.github.composegears.valkyrie.ui.screen.webimport.standard.common.StandardImportScreen
 import io.github.composegears.valkyrie.util.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 val BoxIconsImportScreen by navDestination {
     val navController = navController()
@@ -27,4 +31,10 @@ val BoxIconsImportScreen by navDestination {
             )
         },
     )
+}
+
+@Preview
+@Composable
+private fun BoxIconsImportScreenPreview() = ProjectPreviewTheme {
+    TiamatPreview(BoxIconsImportScreen)
 }

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/standard/lucide/LucideImportScreen.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/standard/lucide/LucideImportScreen.kt
@@ -1,15 +1,19 @@
 package io.github.composegears.valkyrie.ui.screen.webimport.standard.lucide
 
+import androidx.compose.runtime.Composable
 import com.composegears.leviathan.compose.inject
+import com.composegears.tiamat.compose.TiamatPreview
 import com.composegears.tiamat.compose.back
 import com.composegears.tiamat.compose.navController
 import com.composegears.tiamat.compose.navDestination
 import com.composegears.tiamat.compose.navigate
+import io.github.composegears.valkyrie.jewel.tooling.ProjectPreviewTheme
 import io.github.composegears.valkyrie.ui.screen.mode.simple.conversion.SimpleConversionParamsSource.TextSource
 import io.github.composegears.valkyrie.ui.screen.mode.simple.conversion.SimpleConversionScreen
 import io.github.composegears.valkyrie.ui.screen.webimport.standard.common.StandardImportScreen
 import io.github.composegears.valkyrie.ui.screen.webimport.standard.lucide.di.LucideModule
 import io.github.composegears.valkyrie.util.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 val LucideImportScreen by navDestination {
     val navController = navController()
@@ -27,4 +31,10 @@ val LucideImportScreen by navDestination {
             )
         },
     )
+}
+
+@Preview
+@Composable
+private fun LucideImportScreenPreview() = ProjectPreviewTheme {
+    TiamatPreview(LucideImportScreen)
 }

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/standard/remix/RemixImportScreen.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/webimport/standard/remix/RemixImportScreen.kt
@@ -1,15 +1,19 @@
 package io.github.composegears.valkyrie.ui.screen.webimport.standard.remix
 
+import androidx.compose.runtime.Composable
 import com.composegears.leviathan.compose.inject
+import com.composegears.tiamat.compose.TiamatPreview
 import com.composegears.tiamat.compose.back
 import com.composegears.tiamat.compose.navController
 import com.composegears.tiamat.compose.navDestination
 import com.composegears.tiamat.compose.navigate
+import io.github.composegears.valkyrie.jewel.tooling.ProjectPreviewTheme
 import io.github.composegears.valkyrie.ui.screen.mode.simple.conversion.SimpleConversionParamsSource.TextSource
 import io.github.composegears.valkyrie.ui.screen.mode.simple.conversion.SimpleConversionScreen
 import io.github.composegears.valkyrie.ui.screen.webimport.standard.common.StandardImportScreen
 import io.github.composegears.valkyrie.ui.screen.webimport.standard.remix.di.RemixModule
 import io.github.composegears.valkyrie.util.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 val RemixImportScreen by navDestination {
     val navController = navController()
@@ -27,4 +31,10 @@ val RemixImportScreen by navDestination {
             )
         },
     )
+}
+
+@Preview
+@Composable
+private fun RemixImportScreenPreview() = ProjectPreviewTheme {
+    TiamatPreview(RemixImportScreen)
 }


### PR DESCRIPTION

<img width="1389" height="1038" alt="Screenshot 2026-03-06 at 15 31 38" src="https://github.com/user-attachments/assets/6bf28adb-9d70-49e0-9f35-edd2b3d0b2b5" />


---

### 📝 Changelog

If this PR introduces user-facing changes, please update the relevant **Unreleased** section in changelogs:

- [ ] 🔌 [IntelliJ Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md)
- [ ] 🖥️ [CLI](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md)
- [ ] 🐘 [Gradle Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md)
