### PR TITLE
[IconPack] Fix incorrect initial state of `packageName` field in new pack mode when destination folder is selected

### DIFF
--- a/tools/idea-plugin/CHANGELOG.md
+++ b/tools/idea-plugin/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [Gutter] Fixed rendering of icons with gradients and Compose colors
 - [Gutter] Fixed rendering of icons with fully qualified imports
+- [IconPack] Fix incorrect initial state of `packageName` field in new pack mode when destination folder is selected
 
 ## 1.5.0 - 2026-04-17
 

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/common/inputhandler/InputHandler.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/common/inputhandler/InputHandler.kt
@@ -15,15 +15,17 @@ import kotlinx.coroutines.flow.asStateFlow
 interface InputHandler {
     val state: StateFlow<InputFieldState>
 
+    fun init() {}
+
     fun handleInput(change: InputChange)
 
     fun addNestedPack()
     fun removeNestedPack(nestedPack: NestedPack)
 }
 
-abstract class BasicInputHandler(initialState: InputFieldState) : InputHandler {
+abstract class BasicInputHandler : InputHandler {
 
-    private val _state = MutableStateFlow(initialState)
+    private val _state = MutableStateFlow(InputFieldState.Empty)
     override val state: StateFlow<InputFieldState> = _state.asStateFlow()
 
     override fun addNestedPack() {

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/existingpack/ExistingPackInputHandler.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/existingpack/ExistingPackInputHandler.kt
@@ -1,6 +1,5 @@
 package io.github.composegears.valkyrie.ui.screen.mode.iconpack.existingpack
 
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.inputhandler.BasicInputHandler
-import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.model.InputFieldState
 
-class ExistingPackInputHandler : BasicInputHandler(initialState = InputFieldState.Empty)
+class ExistingPackInputHandler : BasicInputHandler()

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/material/MaterialInputHandler.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/material/MaterialInputHandler.kt
@@ -1,6 +1,7 @@
 package io.github.composegears.valkyrie.ui.screen.mode.iconpack.material
 
 import io.github.composegears.valkyrie.parser.unified.util.PackageExtractor
+import io.github.composegears.valkyrie.settings.InMemorySettings
 import io.github.composegears.valkyrie.settings.ValkyriesSettings
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.inputhandler.BasicInputHandler
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.model.InputFieldState
@@ -8,8 +9,8 @@ import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.model.Inpu
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.model.NestedPack
 
 class MaterialInputHandler(
-    settings: ValkyriesSettings,
-) : BasicInputHandler(initialState = settings.materialInputState) {
+    private val inMemorySettings: InMemorySettings,
+) : BasicInputHandler() {
 
     override fun invalidateInputFieldState(
         currentState: InputFieldState,
@@ -21,6 +22,10 @@ class MaterialInputHandler(
         }
 
         return currentState.copy(packageName = currentState.packageName.copy(text = packageNameText))
+    }
+
+    override fun init() {
+        setState(inMemorySettings.current.materialInputState)
     }
 
     companion object {

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/material/MaterialPackViewModel.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/material/MaterialPackViewModel.kt
@@ -37,7 +37,7 @@ class MaterialPackViewModel : ViewModel() {
 
     private val inMemorySettings = inject(DI.core.inMemorySettings)
 
-    private val inputHandler = MaterialInputHandler(inMemorySettings.current)
+    private val inputHandler = MaterialInputHandler(inMemorySettings)
 
     private val _events = Channel<MaterialPackEvent>()
     val events = _events.receiveAsFlow()
@@ -108,6 +108,7 @@ class MaterialPackViewModel : ViewModel() {
     }
 
     private fun initMaterialPack() {
+        inputHandler.init()
         _state.updateState {
             PickedState(inputFieldState = inputHandler.state.value)
         }

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/newpack/NewPackInputHandler.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/newpack/NewPackInputHandler.kt
@@ -1,14 +1,15 @@
 package io.github.composegears.valkyrie.ui.screen.mode.iconpack.newpack
 
 import io.github.composegears.valkyrie.parser.unified.util.PackageExtractor
+import io.github.composegears.valkyrie.settings.InMemorySettings
 import io.github.composegears.valkyrie.settings.ValkyriesSettings
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.inputhandler.BasicInputHandler
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.model.InputFieldState
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.model.InputState
 
 class NewPackInputHandler(
-    settings: ValkyriesSettings,
-) : BasicInputHandler(initialState = settings.newPackInputState) {
+    private val inMemorySettings: InMemorySettings,
+) : BasicInputHandler() {
 
     override fun invalidateInputFieldState(
         currentState: InputFieldState,
@@ -20,6 +21,10 @@ class NewPackInputHandler(
         }
 
         return currentState.copy(packageName = currentState.packageName.copy(text = packageNameText))
+    }
+
+    override fun init() {
+        setState(inMemorySettings.current.newPackInputState)
     }
 
     companion object {

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/newpack/NewPackViewModel.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/newpack/NewPackViewModel.kt
@@ -34,7 +34,7 @@ class NewPackViewModel : ViewModel() {
 
     private val inMemorySettings = inject(DI.core.inMemorySettings)
 
-    private val inputHandler = NewPackInputHandler(inMemorySettings.current)
+    private val inputHandler = NewPackInputHandler(inMemorySettings)
 
     private val _events = Channel<NewPackEvent>()
     val events = _events.receiveAsFlow()
@@ -103,6 +103,7 @@ class NewPackViewModel : ViewModel() {
     }
 
     private fun initDefaultPack() {
+        inputHandler.init()
         _state.updateState {
             NewPackModeState.PickedState(inputFieldState = inputHandler.state.value)
         }


### PR DESCRIPTION


---

### 📝 Changelog

If this PR introduces user-facing changes, please update the relevant **Unreleased** section in changelogs:

- [x] 🔌 [IntelliJ Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md)
- [ ] 🖥️ [CLI](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md)
- [ ] 🐘 [Gradle Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md)
