### PR TITLE
[IconPack] Generated ImageVector files are now appear immediately in the project tree without manual refresh

### DIFF
--- a/tools/idea-plugin/CHANGELOG.md
+++ b/tools/idea-plugin/CHANGELOG.md
@@ -12,14 +12,15 @@
 
 ### Changed
 
-- [IconPack] Don’t override the `.kt` file object if the content hasn’t changed
+- [IconPack] Don't override the `.kt` file object if the content hasn't changed
+- [IconPack] Generated ImageVector files are now appear immediately in the project tree without manual refresh
 
 ### Fixed
 
 - [Gutter] Fixed rendering of icons with gradients and Compose colors
 - [Gutter] Fixed rendering of icons with fully qualified imports
 - [IconPack] Fix incorrect initial state of `packageName` field in new pack mode when destination folder is selected
-- [IconPack] The IDE didn’t automatically display the new icon pack object file
+- [IconPack] The IDE didn't automatically display the new icon pack object file
 
 ## 1.5.0 - 2026-04-17
 

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/common/util/ImageVectorWriter.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/common/util/ImageVectorWriter.kt
@@ -1,0 +1,61 @@
+package io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.util
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.platform.ide.progress.withBackgroundProgress
+import kotlin.io.path.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+
+data class ImageVectorFile(
+    val directoryPath: String,
+    val fileName: String,
+    val content: String,
+)
+
+object ImageVectorWriter {
+
+    @Suppress("InconsistentCommentForJavaParameter")
+    suspend fun saveVectors(
+        project: Project,
+        files: List<ImageVectorFile>,
+    ) {
+        if (files.isEmpty()) return
+
+        withBackgroundProgress(
+            project = project,
+            title = "Generate ImageVector",
+        ) {
+            val rootsToRefresh = withContext(Dispatchers.IO) {
+                files
+                    .groupBy { Path(it.directoryPath) }
+                    .onEach { (dir, dirFiles) ->
+                        ensureActive()
+
+                        dir.createDirectories()
+
+                        dirFiles.forEach { (_, fileName, content) ->
+                            dir.resolve(fileName).writeText(content)
+                        }
+                    }
+                    .keys
+                    .toList()
+            }
+
+            LocalFileSystem.getInstance()
+                .refreshNioFiles(
+                    /* files = */
+                    rootsToRefresh,
+                    /* async = */
+                    true,
+                    /* recursive = */
+                    true,
+                    /* onFinish = */
+                    null,
+                )
+        }
+    }
+}

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionScreen.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionScreen.kt
@@ -32,9 +32,9 @@ import com.composegears.tiamat.compose.navController
 import com.composegears.tiamat.compose.navDestination
 import com.composegears.tiamat.compose.navigate
 import com.composegears.tiamat.compose.saveableViewModel
-import com.intellij.openapi.vfs.VirtualFileManager
 import io.github.composegears.valkyrie.jewel.banner.BannerMessage.WarningBanner
 import io.github.composegears.valkyrie.jewel.banner.rememberBannerManager
+import io.github.composegears.valkyrie.jewel.platform.LocalProject
 import io.github.composegears.valkyrie.jewel.platform.rememberMultiSelectDragAndDropHandler
 import io.github.composegears.valkyrie.jewel.tooling.PreviewNavigationControls
 import io.github.composegears.valkyrie.jewel.tooling.PreviewTheme
@@ -68,6 +68,7 @@ import org.jetbrains.jewel.ui.component.Text
 val IconPackConversionScreen by navDestination<PendingPathData> {
     val navController = navController()
     val pendingData = navArgsOrNull()
+    val project = LocalProject.current
 
     val viewModel = saveableViewModel {
         IconPackConversionViewModel(
@@ -87,9 +88,6 @@ val IconPackConversionScreen by navDestination<PendingPathData> {
                     navArgs = event.iconContent,
                 )
             }
-            is ConversionEvent.ImportCompleted -> {
-                VirtualFileManager.getInstance().asyncRefresh()
-            }
             is ConversionEvent.NothingToImport -> {
                 bannerManager.show(message = WarningBanner(text = message("iconpack.conversion.nothing.import")))
             }
@@ -108,7 +106,7 @@ val IconPackConversionScreen by navDestination<PendingPathData> {
         onDeleteIcon = viewModel::deleteIcon,
         onReset = viewModel::reset,
         onPreviewClick = viewModel::showPreview,
-        onImport = viewModel::import,
+        onImport = { viewModel.import(project) },
         onRenameIcon = viewModel::renameIcon,
         onResolveIssues = viewModel::resolveImportIssues,
     )

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionViewModel.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/mode/iconpack/conversion/IconPackConversionViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.composegears.leviathan.compose.inject
 import com.composegears.tiamat.navigation.MutableSavedState
 import com.composegears.tiamat.navigation.recordOf
+import com.intellij.openapi.project.Project
 import io.github.composegears.valkyrie.generator.jvm.imagevector.ImageVectorGenerator
 import io.github.composegears.valkyrie.generator.jvm.imagevector.ImageVectorGeneratorConfig
 import io.github.composegears.valkyrie.parser.unified.ParserType
@@ -13,11 +14,12 @@ import io.github.composegears.valkyrie.parser.unified.ext.isSvg
 import io.github.composegears.valkyrie.parser.unified.ext.isXml
 import io.github.composegears.valkyrie.parser.unified.ext.toIOPath
 import io.github.composegears.valkyrie.sdk.core.extensions.safeAs
-import io.github.composegears.valkyrie.sdk.core.extensions.writeToKt
 import io.github.composegears.valkyrie.settings.ValkyriesSettings
 import io.github.composegears.valkyrie.ui.di.DI
 import io.github.composegears.valkyrie.ui.extension.updateState
 import io.github.composegears.valkyrie.ui.foundation.picker.PickerEvent
+import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.util.ImageVectorFile
+import io.github.composegears.valkyrie.ui.screen.mode.iconpack.common.util.ImageVectorWriter
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.ConversionEvent.OpenPreview
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconPackConversionState.BatchProcessing
 import io.github.composegears.valkyrie.ui.screen.mode.iconpack.conversion.IconPackConversionState.IconsPickering
@@ -36,7 +38,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class IconPackConversionViewModel(
     savedState: MutableSavedState,
@@ -171,7 +172,7 @@ class IconPackConversionViewModel(
         _events.send(OpenPreview(output.content))
     }
 
-    fun import() = viewModelScope.launch(Dispatchers.Default) {
+    fun import(project: Project) = viewModelScope.launch(Dispatchers.Default) {
         val icons = when (val state = _state.value) {
             is BatchProcessing.IconPackCreationState -> state.icons
             else -> return@launch
@@ -181,9 +182,9 @@ class IconPackConversionViewModel(
 
         val settings = inMemorySettings.current
 
-        icons
+        val filesToWrite = icons
             .filterIsInstance<BatchIcon.Valid>()
-            .forEach { icon ->
+            .map { icon ->
                 when (val iconPack = icon.iconPack) {
                     is IconPack.Nested -> {
                         val vectorSpecOutput = ImageVectorGenerator.convert(
@@ -194,16 +195,15 @@ class IconPackConversionViewModel(
                                 nestedPackName = iconPack.currentNestedPack,
                             ),
                         )
-
-                        withContext(Dispatchers.IO) {
-                            vectorSpecOutput.content.writeToKt(
-                                outputDir = when {
-                                    settings.flatPackage -> settings.iconPackDestination
-                                    else -> "${settings.iconPackDestination}/${iconPack.currentNestedPack.lowercase()}"
-                                },
-                                nameWithoutExtension = vectorSpecOutput.name,
-                            )
+                        val outputDir = when {
+                            settings.flatPackage -> settings.iconPackDestination
+                            else -> "${settings.iconPackDestination}/${iconPack.currentNestedPack.lowercase()}"
                         }
+                        ImageVectorFile(
+                            directoryPath = outputDir,
+                            fileName = "${vectorSpecOutput.name}.kt",
+                            content = vectorSpecOutput.content,
+                        )
                     }
                     is IconPack.Single -> {
                         val vectorSpecOutput = ImageVectorGenerator.convert(
@@ -214,18 +214,20 @@ class IconPackConversionViewModel(
                                 nestedPackName = "",
                             ),
                         )
-
-                        withContext(Dispatchers.IO) {
-                            vectorSpecOutput.content.writeToKt(
-                                outputDir = settings.iconPackDestination,
-                                nameWithoutExtension = vectorSpecOutput.name,
-                            )
-                        }
+                        ImageVectorFile(
+                            directoryPath = settings.iconPackDestination,
+                            fileName = "${vectorSpecOutput.name}.kt",
+                            content = vectorSpecOutput.content,
+                        )
                     }
                 }
             }
 
-        _events.send(ConversionEvent.ImportCompleted)
+        ImageVectorWriter.saveVectors(
+            project = project,
+            files = filesToWrite,
+        )
+
         reset()
     }
 
@@ -383,6 +385,5 @@ class IconPackConversionViewModel(
 
 sealed interface ConversionEvent {
     data class OpenPreview(val iconContent: String) : ConversionEvent
-    data object ImportCompleted : ConversionEvent
     data object NothingToImport : ConversionEvent
 }


### PR DESCRIPTION
- closes: https://github.com/ComposeGears/Valkyrie/issues/769


https://github.com/user-attachments/assets/7d07680c-e2c8-4baf-80a3-78db47a39070



---

### 📝 Changelog

If this PR introduces user-facing changes, please update the relevant **Unreleased** section in changelogs:

- [x] 🔌 [IntelliJ Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md)
- [ ] 🖥️ [CLI](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md)
- [ ] 🐘 [Gradle Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md)
