### PR TITLE
Support inherited SVG paint attributes

### DIFF
--- a/components/parser/kmp/svg/build.gradle.kts
+++ b/components/parser/kmp/svg/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 }
 
 kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-parameters")
+    }
+
     sourceSets {
         commonMain.dependencies {
             implementation(projects.sdk.ir.core)

--- a/components/parser/kmp/svg/src/commonMain/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVG.kt
+++ b/components/parser/kmp/svg/src/commonMain/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVG.kt
@@ -17,6 +17,12 @@ internal data class SVG(
     @SerialName("height") val height: String? = null,
     @SerialName("viewBox") val viewBox: String? = null,
     @SerialName("fill") val fill: String? = null,
+    @SerialName("stroke") val strokeColor: String? = null,
+    @SerialName("stroke-width") val strokeWidth: String? = null,
+    @SerialName("stroke-linecap") val strokeLineCap: String? = null,
+    @SerialName("stroke-linejoin") val strokeLineJoin: String? = null,
+    @SerialName("stroke-opacity") val strokeAlpha: String? = null,
+    @SerialName("stroke-miterlimit") val strokeMiter: String? = null,
     @XmlPolyChildren([GROUP, PATH, CIRCLE, RECTANGLE, ELLIPSE, POLYGON])
     val children: List<@Polymorphic Child> = emptyList(),
 ) {
@@ -48,6 +54,7 @@ internal data class SVG(
     data class Group(
         @SerialName("id") override val id: String? = null,
         @SerialName("transform") val transform: String? = null,
+        @SerialName("fill") val fill: String? = null,
         @XmlPolyChildren([GROUP, PATH, CIRCLE, RECTANGLE, ELLIPSE, POLYGON])
         val children: List<@Polymorphic Child> = emptyList(),
 

--- a/components/parser/kmp/svg/src/commonMain/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVGParser.kt
+++ b/components/parser/kmp/svg/src/commonMain/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVGParser.kt
@@ -68,11 +68,10 @@ object SVGParser {
     context(paintContext: PaintContext)
     private fun SVG.Path.toVectorPath(): IrVectorNode.IrPath {
         val resolvedFill = fill ?: paintContext.fill
-        val resolvedStrokeColor = strokeColor ?: paintContext.strokeColor
         var fillColor: IrColor? = resolvedFill?.let(SvgColorParser::parse)
         // NOTE: Only when fill and strokeColor is null use black FillColor as default color as
         //       fill can be none resulting to null.
-        fillColor = if (resolvedFill == null && resolvedStrokeColor == null) Black else fillColor
+        fillColor = if (resolvedFill == null && strokeColor == null) Black else fillColor
         val stroke = getSVGStrokeWithDefaults()
         return IrVectorNode.IrPath(
             name = id.orEmpty(),

--- a/components/parser/kmp/svg/src/commonMain/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVGParser.kt
+++ b/components/parser/kmp/svg/src/commonMain/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVGParser.kt
@@ -39,10 +39,23 @@ object SVGParser {
             defaultHeight = height ?: DEFAULT_HEIGHT,
             viewportWidth = rect?.width ?: width ?: DEFAULT_WIDTH,
             viewportHeight = rect?.height ?: height ?: DEFAULT_HEIGHT,
-            nodes = children.mapNotNull { it.toIrVectorNode() },
+            nodes = with(toPaintContext()) {
+                children.mapNotNull { it.toIrVectorNode() }
+            },
         )
     }
 
+    private fun SVG.toPaintContext(): PaintContext = PaintContext(
+        fill = fill,
+        strokeColor = strokeColor,
+        strokeWidth = strokeWidth,
+        strokeLineCap = strokeLineCap,
+        strokeLineJoin = strokeLineJoin,
+        strokeAlpha = strokeAlpha,
+        strokeMiter = strokeMiter,
+    )
+
+    context(paintContext: PaintContext)
     private fun SVG.Child.toIrVectorNode(): IrVectorNode? = when (this) {
         is SVG.Path -> toVectorPath()
         is SVG.Circle -> toVectorPath()
@@ -52,11 +65,14 @@ object SVGParser {
         is SVG.Ellipse -> toVectorPath()
     }
 
+    context(paintContext: PaintContext)
     private fun SVG.Path.toVectorPath(): IrVectorNode.IrPath {
-        var fillColor: IrColor? = fill?.let(SvgColorParser::parse)
+        val resolvedFill = fill ?: paintContext.fill
+        val resolvedStrokeColor = strokeColor ?: paintContext.strokeColor
+        var fillColor: IrColor? = resolvedFill?.let(SvgColorParser::parse)
         // NOTE: Only when fill and strokeColor is null use black FillColor as default color as
         //       fill can be none resulting to null.
-        fillColor = if (fill == null && strokeColor == null) Black else fillColor
+        fillColor = if (resolvedFill == null && resolvedStrokeColor == null) Black else fillColor
         val stroke = getSVGStrokeWithDefaults()
         return IrVectorNode.IrPath(
             name = id.orEmpty(),
@@ -73,15 +89,16 @@ object SVGParser {
         )
     }
 
+    context(paintContext: PaintContext)
     private fun SVG.Circle.toVectorPath(): IrVectorNode.IrPath {
         val cx = centerX.toFloat()
         val cy = centerY.toFloat()
         val r = radius.toFloat()
-        val color = fill?.let(SvgColorParser::parse) ?: Black
+        val fill = resolveFill(fill)
         val stroke = getSVGStrokeWithDefaults()
         return IrVectorNode.IrPath(
             name = id.orEmpty(),
-            fill = IrFill.Color(color),
+            fill = fill,
             fillAlpha = fillAlpha?.toFloat() ?: 1f,
             stroke = stroke.color?.let { IrStroke.Color(it) },
             strokeAlpha = stroke.alpha,
@@ -115,11 +132,12 @@ object SVGParser {
         )
     }
 
+    context(paintContext: PaintContext)
     private fun SVG.Polygon.toVectorPath(): IrVectorNode.IrPath {
         val stroke = getSVGStrokeWithDefaults()
         return IrVectorNode.IrPath(
             name = id.orEmpty(),
-            fill = if (fill != null) SvgColorParser.parse(fill)?.let { IrFill.Color(it) } else IrFill.Color(Black),
+            fill = resolveFill(fill),
             fillAlpha = fillAlpha?.toFloat() ?: 1f,
             stroke = stroke.color?.let { IrStroke.Color(it) },
             strokeAlpha = stroke.alpha,
@@ -144,13 +162,25 @@ object SVGParser {
         )
     }
 
+    context(paintContext: PaintContext)
     private fun SVG.Group.toVectorGroup(): IrVectorNode.IrGroup {
+        val groupContext = PaintContext(
+            fill = fill ?: paintContext.fill,
+            strokeColor = strokeColor ?: paintContext.strokeColor,
+            strokeWidth = strokeWidth ?: paintContext.strokeWidth,
+            strokeLineCap = strokeLineCap ?: paintContext.strokeLineCap,
+            strokeLineJoin = strokeLineJoin ?: paintContext.strokeLineJoin,
+            strokeAlpha = strokeAlpha ?: paintContext.strokeAlpha,
+            strokeMiter = strokeMiter ?: paintContext.strokeMiter,
+        )
         val pivot = transform?.getPivot() ?: Translation.Default
         val translation = transform?.getTranslation() ?: Translation.Default
         val scale = transform?.getScale() ?: Scale.Default
         return IrVectorNode.IrGroup(
             name = id.orEmpty(),
-            nodes = children.mapNotNull { it.toIrVectorNode() }.toMutableList(),
+            nodes = with(groupContext) {
+                children.mapNotNull { it.toIrVectorNode() }.toMutableList()
+            },
             rotate = transform?.getRotation() ?: 0f,
             pivotX = pivot.x,
             pivotY = pivot.y,
@@ -163,6 +193,7 @@ object SVGParser {
         )
     }
 
+    context(paintContext: PaintContext)
     private fun SVG.Rectangle.toVectorPath(): IrVectorNode.IrPath? {
         val x = x.toFloat()
         val y = y.toFloat()
@@ -174,7 +205,7 @@ object SVGParser {
         return IrVectorNode.IrPath(
             name = id.orEmpty(),
             pathFillType = IrPathFillType.NonZero,
-            fill = if (fill != null) SvgColorParser.parse(fill)?.let { IrFill.Color(it) } else IrFill.Color(Black),
+            fill = resolveFill(fill),
             fillAlpha = 1f,
             stroke = stroke.color?.let { IrStroke.Color(it) },
             strokeAlpha = stroke.alpha,
@@ -192,6 +223,7 @@ object SVGParser {
         )
     }
 
+    context(paintContext: PaintContext)
     private fun SVG.Ellipse.toVectorPath(): IrVectorNode.IrPath {
         val cx = centerX.toFloat()
         val cy = centerY.toFloat()
@@ -203,7 +235,7 @@ object SVGParser {
         return IrVectorNode.IrPath(
             name = id.orEmpty(),
             pathFillType = IrPathFillType.NonZero,
-            fill = if (fill != null) SvgColorParser.parse(fill)?.let { IrFill.Color(it) } else IrFill.Color(Black),
+            fill = resolveFill(fill),
             fillAlpha = 1f,
             stroke = stroke.color?.let { IrStroke.Color(it) },
             strokeAlpha = stroke.alpha,
@@ -261,6 +293,26 @@ object SVGParser {
         return functionStart.substring(1 until endIndex).split(" ", ",").map { it.toFloat() }
     }
 
+    context(paintContext: PaintContext)
+    private fun resolveFill(fill: String?): IrFill.Color? {
+        val resolvedFill = fill ?: paintContext.fill
+        val color = when (resolvedFill) {
+            null -> Black
+            else -> SvgColorParser.parse(resolvedFill)
+        }
+        return color?.let { IrFill.Color(it) }
+    }
+
     @Suppress("PrivatePropertyName")
     private val Black: IrColor = IrColor(0xff000000)
 }
+
+internal data class PaintContext(
+    val fill: String?,
+    val strokeColor: String?,
+    val strokeWidth: String?,
+    val strokeLineCap: String?,
+    val strokeLineJoin: String?,
+    val strokeAlpha: String?,
+    val strokeMiter: String?,
+)

--- a/components/parser/kmp/svg/src/commonMain/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SvgExtensions.kt
+++ b/components/parser/kmp/svg/src/commonMain/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SvgExtensions.kt
@@ -4,13 +4,14 @@ import io.github.composegears.valkyrie.sdk.ir.core.IrPathFillType
 import io.github.composegears.valkyrie.sdk.ir.core.IrStrokeLineCap
 import io.github.composegears.valkyrie.sdk.ir.core.IrStrokeLineJoin
 
+context(paintContext: PaintContext)
 internal fun SVG.Child.getSVGStrokeWithDefaults(): SVGStroke = SVGStroke(
-    color = strokeColor?.let { SvgColorParser.parse(it) },
-    alpha = strokeAlpha?.toFloat() ?: 1f,
-    width = strokeWidth?.toFloat() ?: 0f,
-    cap = strokeLineCap?.let { SVGStroke.Cap(it) } ?: SVGStroke.Cap.Butt,
-    join = strokeLineJoin?.let { SVGStroke.Join(it) } ?: SVGStroke.Join.Miter,
-    miter = strokeMiter?.toFloat() ?: 4f,
+    color = (strokeColor ?: paintContext.strokeColor)?.let { SvgColorParser.parse(it) },
+    alpha = (strokeAlpha ?: paintContext.strokeAlpha)?.toFloat() ?: 1f,
+    width = (strokeWidth ?: paintContext.strokeWidth)?.toFloat() ?: 0f,
+    cap = (strokeLineCap ?: paintContext.strokeLineCap)?.let { SVGStroke.Cap(it) } ?: SVGStroke.Cap.Butt,
+    join = (strokeLineJoin ?: paintContext.strokeLineJoin)?.let { SVGStroke.Join(it) } ?: SVGStroke.Join.Miter,
+    miter = (strokeMiter ?: paintContext.strokeMiter)?.toFloat() ?: 4f,
 )
 
 internal fun SVGStroke.Cap.toIrStrokeLineCap(): IrStrokeLineCap = when (this) {

--- a/components/parser/kmp/svg/src/commonTest/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVGParserTest.kt
+++ b/components/parser/kmp/svg/src/commonTest/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVGParserTest.kt
@@ -100,6 +100,34 @@ internal class SVGParserTest {
     }
 
     @Test
+    fun parse_path_with_inherited_root_stroke_defaults_to_black_fill() {
+        val svg = svg(fill = null, stroke = "#ff0000") {
+            """<path d="M4 4h16"/>"""
+        }
+
+        assertEquals(
+            actual = SVGParser.parse(svg).nodes,
+            expected = listOf(
+                IrVectorNode.IrPath(
+                    pathFillType = IrPathFillType.NonZero,
+                    fill = IrFill.Color(IrColor(0xFF000000)),
+                    paths = listOf(
+                        IrPathNode.MoveTo(4f, 4f),
+                        IrPathNode.RelativeHorizontalTo(16f),
+                    ),
+                    fillAlpha = 1f,
+                    stroke = IrStroke.Color(IrColor(0xFFFF0000)),
+                    strokeAlpha = 1f,
+                    strokeLineWidth = 0f,
+                    strokeLineCap = IrStrokeLineCap.Butt,
+                    strokeLineJoin = IrStrokeLineJoin.Miter,
+                    strokeLineMiter = 4f,
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun parse_path_with_inherited_group_fill() {
         val svg = svg(fill = "none") {
             """

--- a/components/parser/kmp/svg/src/commonTest/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVGParserTest.kt
+++ b/components/parser/kmp/svg/src/commonTest/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/SVGParserTest.kt
@@ -43,7 +43,7 @@ internal class SVGParserTest {
 
     @Test
     fun parse_path_with_stroke_from_SVG() {
-        val svg = svg {
+        val svg = svg(fill = "none") {
             """<path d="" stroke="black" stroke-width="2" stroke-linecap="square" stroke-linejoin="round" stroke-miterlimit="0.25" stroke-opacity="0.5"/>"""
         }
         assertEquals(
@@ -62,6 +62,69 @@ internal class SVGParserTest {
                     strokeLineMiter = .25f,
                 ),
             ),
+        )
+    }
+
+    @Test
+    fun parse_path_with_inherited_root_stroke() {
+        val svg = svg(
+            fill = "none",
+            stroke = "#ff0000",
+            strokeWidth = "1.5",
+            strokeLineCap = "round",
+            strokeLineJoin = "round",
+        ) {
+            """<path d="M4 4h16"/>"""
+        }
+
+        assertEquals(
+            actual = SVGParser.parse(svg).nodes,
+            expected = listOf(
+                IrVectorNode.IrPath(
+                    pathFillType = IrPathFillType.NonZero,
+                    fill = null,
+                    paths = listOf(
+                        IrPathNode.MoveTo(4f, 4f),
+                        IrPathNode.RelativeHorizontalTo(16f),
+                    ),
+                    fillAlpha = 1f,
+                    stroke = IrStroke.Color(IrColor(0xFFFF0000)),
+                    strokeAlpha = 1f,
+                    strokeLineWidth = 1.5f,
+                    strokeLineCap = IrStrokeLineCap.Round,
+                    strokeLineJoin = IrStrokeLineJoin.Round,
+                    strokeLineMiter = 4f,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun parse_path_with_inherited_group_fill() {
+        val svg = svg(fill = "none") {
+            """
+            <g fill="#ff0000">
+                <path d="M4 4h16"/>
+            </g>
+            """
+        }
+
+        val actual: List<IrVectorNode> = SVGParser.parse(svg).groups.single().nodes
+
+        assertEquals(
+            expected = listOf<IrVectorNode>(
+                IrVectorNode.IrPath(
+                    pathFillType = IrPathFillType.NonZero,
+                    fill = IrFill.Color(IrColor(0xFFFF0000)),
+                    paths = listOf(
+                        IrPathNode.MoveTo(4f, 4f),
+                        IrPathNode.RelativeHorizontalTo(16f),
+                    ),
+                    fillAlpha = 1f,
+                    stroke = null,
+                ),
+            ),
+            actual = actual,
         )
     }
 

--- a/components/parser/kmp/svg/src/commonTest/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/Utils.kt
+++ b/components/parser/kmp/svg/src/commonTest/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/Utils.kt
@@ -19,6 +19,10 @@ internal inline fun svg(
     height: String = "24px",
     viewBox: String? = "0 0 24 24",
     fill: String = "#000000",
+    stroke: String? = null,
+    strokeWidth: String? = null,
+    strokeLineCap: String? = null,
+    strokeLineJoin: String? = null,
     block: () -> String,
 ): String {
     return buildString {
@@ -27,6 +31,10 @@ internal inline fun svg(
         appendLine("""height="$height"""")
         appendLine("""width="$width"""")
         if (viewBox != null) appendLine("""viewBox="$viewBox"""")
+        if (stroke != null) appendLine("""stroke="$stroke"""")
+        if (strokeWidth != null) appendLine("""stroke-width="$strokeWidth"""")
+        if (strokeLineCap != null) appendLine("""stroke-linecap="$strokeLineCap"""")
+        if (strokeLineJoin != null) appendLine("""stroke-linejoin="$strokeLineJoin"""")
         appendLine("""fill="$fill">""")
         appendLine(block())
         appendLine("</svg>")

--- a/components/parser/kmp/svg/src/commonTest/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/Utils.kt
+++ b/components/parser/kmp/svg/src/commonTest/kotlin/io/github/composegears/valkyrie/parser/kmp/svg/Utils.kt
@@ -4,7 +4,7 @@ internal fun testSVG(
     height: String = "24px",
     viewBox: String = "0 0 24 24",
     width: String = "24px",
-    fill: String = "#000000",
+    fill: String? = "#000000",
     children: List<SVG.Child>,
 ) = SVG(
     width = width,
@@ -18,7 +18,7 @@ internal inline fun svg(
     width: String = "24px",
     height: String = "24px",
     viewBox: String? = "0 0 24 24",
-    fill: String = "#000000",
+    fill: String? = "#000000",
     stroke: String? = null,
     strokeWidth: String? = null,
     strokeLineCap: String? = null,
@@ -35,7 +35,11 @@ internal inline fun svg(
         if (strokeWidth != null) appendLine("""stroke-width="$strokeWidth"""")
         if (strokeLineCap != null) appendLine("""stroke-linecap="$strokeLineCap"""")
         if (strokeLineJoin != null) appendLine("""stroke-linejoin="$strokeLineJoin"""")
-        appendLine("""fill="$fill">""")
+        if (fill != null) {
+            appendLine("""fill="$fill">""")
+        } else {
+            appendLine(">")
+        }
         appendLine(block())
         appendLine("</svg>")
     }


### PR DESCRIPTION
- Add SVG parser support for inherited root/group paint attributes.
- Propagate inherited fill, stroke, and stroke styling through SVG groups and shapes.

---

### 📝 Changelog

If this PR introduces user-facing changes, please update the relevant **Unreleased** section in changelogs:

- [ ] 🔌 [IntelliJ Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md)
- [ ] 🖥️ [CLI](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md)
- [ ] 🐘 [Gradle Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md)
