### PR TITLE
[ImageVector to XML] Use kt file name with `ic_` prefix for converted XML icon

### DIFF
--- a/tools/idea-plugin/CHANGELOG.md
+++ b/tools/idea-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - [IconPack] Replace code snippet tooltip on Package and IconPack name fields with a plain text description tooltip
+- [ImageVector to XML] Use kt file name with `ic_` prefix for converted XML icon
 
 ### Fixed
 

--- a/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/tools/imagevectorxml/conversion/ImageVectorXmlViewModel.kt
+++ b/tools/idea-plugin/src/main/kotlin/io/github/composegears/valkyrie/ui/screen/tools/imagevectorxml/conversion/ImageVectorXmlViewModel.kt
@@ -83,7 +83,9 @@ class ImageVectorXmlViewModel(
             return@launch
         }
 
-        parseImageVectorToXml(ktFile)
+        val fileName = ktFile.virtualFile.nameWithoutExtension
+
+        parseImageVectorToXml(ktFile, preferredName = "ic_${sanitizeResourceName(fileName)}")
             .onFailure {
                 stateRecord.value = ImageVectorXmlState.Error(
                     message = "Failed to parse ImageVector from file",
@@ -140,7 +142,10 @@ class ImageVectorXmlViewModel(
         )
     }
 
-    private suspend fun parseImageVectorToXml(ktFile: KtFile): Result<XmlContent> {
+    private suspend fun parseImageVectorToXml(
+        ktFile: KtFile,
+        preferredName: String? = null,
+    ): Result<XmlContent> {
         return withContext(Dispatchers.Default) {
             runCatching {
                 readAction {
@@ -148,7 +153,7 @@ class ImageVectorXmlViewModel(
                         ?: error("Failed to parse image vector psi")
 
                     val xmlCode = irImageVector.toVectorXmlString()
-                    val iconName = irImageVector.name.lowercase().ifEmpty { "Icon" }
+                    val iconName = preferredName ?: sanitizeResourceName(irImageVector.name)
 
                     XmlContent(
                         name = iconName,
@@ -160,3 +165,13 @@ class ImageVectorXmlViewModel(
         }
     }
 }
+
+/**
+ * Normalizes a file name into a valid Android XML resource name segment: lowercase, with any
+ * character outside [a-z0-9] replaced by `_`. Leading/trailing underscores are trimmed and an
+ * empty result falls back to "icon". The caller prefixes it with "ic_", guaranteeing a letter start.
+ */
+internal fun sanitizeResourceName(name: String): String = name.lowercase()
+    .replace("[^a-z0-9]".toRegex(), "_")
+    .trim('_')
+    .ifEmpty { "icon" }

--- a/tools/idea-plugin/src/test/kotlin/io/github/composegears/valkyrie/ui/screen/tools/imagevectorxml/conversion/ImageVectorXmlViewModelTest.kt
+++ b/tools/idea-plugin/src/test/kotlin/io/github/composegears/valkyrie/ui/screen/tools/imagevectorxml/conversion/ImageVectorXmlViewModelTest.kt
@@ -1,0 +1,68 @@
+package io.github.composegears.valkyrie.ui.screen.tools.imagevectorxml.conversion
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class ImageVectorXmlViewModelTest {
+
+    @Test
+    fun `sanitizeResourceName lowercases uppercase filename`() {
+        assertThat(sanitizeResourceName("Kotlin")).isEqualTo("kotlin")
+    }
+
+    @Test
+    fun `sanitizeResourceName replaces hyphen with underscore`() {
+        assertThat(sanitizeResourceName("my-icon")).isEqualTo("my_icon")
+    }
+
+    @Test
+    fun `sanitizeResourceName replaces punctuation with underscore`() {
+        assertThat(sanitizeResourceName("My.Icon")).isEqualTo("my_icon")
+        assertThat(sanitizeResourceName("My Icon-Name!")).isEqualTo("my_icon_name")
+    }
+
+    @Test
+    fun `sanitizeResourceName normalizes Material icon name with dot separator`() {
+        // irImageVector.name coming from an Icons.Filled.WithoutPath declaration
+        assertThat(sanitizeResourceName("Filled.WithoutPath")).isEqualTo("filled_withoutpath")
+    }
+
+    @Test
+    fun `sanitizeResourceName keeps already valid name`() {
+        assertThat(sanitizeResourceName("icon")).isEqualTo("icon")
+        assertThat(sanitizeResourceName("my_icon_2")).isEqualTo("my_icon_2")
+    }
+
+    @Test
+    fun `sanitizeResourceName lowercases mixed-case names`() {
+        assertThat(sanitizeResourceName("UPPER_CASE")).isEqualTo("upper_case")
+        assertThat(sanitizeResourceName("OutlinedIcon")).isEqualTo("outlinedicon")
+    }
+
+    @Test
+    fun `sanitizeResourceName falls back to icon for empty name`() {
+        assertThat(sanitizeResourceName("")).isEqualTo("icon")
+    }
+
+    @Test
+    fun `sanitizeResourceName preserves digits-only name`() {
+        // digits are allowed (in [a-z0-9]), so the name survives unchanged with no fallback
+        assertThat(sanitizeResourceName("123")).isEqualTo("123")
+    }
+
+    @Test
+    fun `sanitizeResourceName falls back to icon for punctuation-only name`() {
+        assertThat(sanitizeResourceName("---...")).isEqualTo("icon")
+    }
+
+    @Test
+    fun `preferred name is ic_ plus sanitized filename for uppercase source`() {
+        assertThat("ic_${sanitizeResourceName("Kotlin")}").isEqualTo("ic_kotlin")
+    }
+
+    @Test
+    fun `preferred name is ic_ plus sanitized filename for punctuation source`() {
+        assertThat("ic_${sanitizeResourceName("my-icon")}").isEqualTo("ic_my_icon")
+    }
+}


### PR DESCRIPTION

<img width="1592" height="981" alt="Screenshot 2026-07-22 at 22 19 13" src="https://github.com/user-attachments/assets/a425e42d-4f0a-42c5-9d76-da534515c101" />

---

### 📝 Changelog

If this PR introduces user-facing changes, please update the relevant **Unreleased** section in changelogs:

- [ ] 🔌 [IntelliJ Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md)
- [ ] 🖥️ [CLI](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md)
- [ ] 🐘 [Gradle Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md)
