### PR TITLE
Add coroutines version check and include testImplementation deps

### DIFF
--- a/build-logic/src/main/kotlin/io/github/composegears/valkyrie/task/CheckVersionCompatibility.kt
+++ b/build-logic/src/main/kotlin/io/github/composegears/valkyrie/task/CheckVersionCompatibility.kt
@@ -20,10 +20,14 @@ abstract class CheckVersionCompatibility : DefaultTask() {
     @get:Input
     abstract val maxComposeVersion: Property<String>
 
+    @get:Input
+    abstract val maxCoroutinesVersion: Property<String>
+
     @TaskAction
     fun check() {
         val maxKotlin = SemVer.parse(maxKotlinVersion.get())
         val maxCompose = SemVer.parse(maxComposeVersion.get())
+        val maxCoroutines = SemVer.parse(maxCoroutinesVersion.get())
 
         val violations = resolvedComponents.get()
             .mapNotNull { (coordinate, dependents) ->
@@ -38,6 +42,8 @@ abstract class CheckVersionCompatibility : DefaultTask() {
                         "\t- $group:$name:$version  (max supported: $maxKotlin)$requiredBy"
                     group.startsWith("org.jetbrains.compose") && SemVer.parse(version) > maxCompose ->
                         "\t- $group:$name:$version  (max supported: $maxCompose)$requiredBy"
+                    group == "org.jetbrains.kotlinx" && name.startsWith("kotlinx-coroutines") && SemVer.parse(version) > maxCoroutines ->
+                        "\t- $group:$name:$version  (max supported: $maxCoroutines)$requiredBy"
                     else -> null
                 }
             }
@@ -51,6 +57,6 @@ abstract class CheckVersionCompatibility : DefaultTask() {
                 },
             )
         }
-        logger.lifecycle("✅ All dependencies are compatible (kotlin ≤ $maxKotlin, compose ≤ $maxCompose)")
+        logger.lifecycle("✅ All dependencies are compatible (kotlin ≤ $maxKotlin, compose ≤ $maxCompose, coroutines ≤ $maxCoroutines)")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 compose = "1.11.0"
+# https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#coroutinesLibraries
+coroutines = "1.10.2"
 intellij = "2.18.1"
 jacoco = "0.8.13"
 jdkRelease = "25"
@@ -44,7 +46,7 @@ assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 junit5-jupiter = "org.junit.jupiter:junit-jupiter:6.1.2"
 junit-launcher = "org.junit.platform:junit-platform-launcher:6.1.2"
 junit4 = "junit:junit:4.13.2"
-kotlin-coroutines-test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
+kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 semver = "net.swiftzer.semver:semver:2.1.0"

--- a/tools/idea-plugin/build.gradle.kts
+++ b/tools/idea-plugin/build.gradle.kts
@@ -183,6 +183,7 @@ tasks.register<CheckVersionCompatibility>("checkVersionCompatibility") {
         isCanBeResolved = true
         isCanBeConsumed = false
         dependencies.addAll(configurations.getByName("implementation").dependencies)
+        dependencies.addAll(configurations.getByName("testImplementation").dependencies)
     }
     resolvedComponents = checkConfig.map { config ->
         val result = mutableMapOf<String, MutableSet<String>>()
@@ -198,4 +199,5 @@ tasks.register<CheckVersionCompatibility>("checkVersionCompatibility") {
     }
     maxKotlinVersion = libs.versions.kotlin
     maxComposeVersion = libs.versions.compose
+    maxCoroutinesVersion = libs.versions.coroutines
 }


### PR DESCRIPTION
checkVersionCompatibility previously ignored testImplementation, so kotlin.coroutines.test could exceed the max supported coroutines version without being caught.

---

### 📝 Changelog

If this PR introduces user-facing changes, please update the relevant **Unreleased** section in changelogs:

- [ ] 🔌 [IntelliJ Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md)
- [ ] 🖥️ [CLI](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md)
- [ ] 🐘 [Gradle Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md)
