### PR TITLE
Declare explicit Compose/Jewel module dependencies in IDEA plugin

### DIFF
--- a/.github/workflows/verify-plugin.yml
+++ b/.github/workflows/verify-plugin.yml
@@ -1,0 +1,19 @@
+name: Verify IntelliJ Plugin
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-java
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-disabled: true
+
+      - name: Verify IntelliJ plugin
+        run: ./gradlew verifyPlugin

--- a/tools/idea-plugin/CHANGELOG.md
+++ b/tools/idea-plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Migrate to IntelliJ IDEA 2026.2, Kotlin 2.3.20, and Java 25
+- Declare explicit Compose/Jewel platform module dependencies instead of `com.intellij.modules.compose`
 
 ### Fixed
 

--- a/tools/idea-plugin/build.gradle.kts
+++ b/tools/idea-plugin/build.gradle.kts
@@ -133,6 +133,10 @@ intellijPlatform {
                 type = IntelliJPlatformType.IntellijIdea,
                 version = "2026.2",
             )
+            create(
+                type = IntelliJPlatformType.AndroidStudio,
+                version = "2026.2",
+            )
         }
     }
     signing {

--- a/tools/idea-plugin/build.gradle.kts
+++ b/tools/idea-plugin/build.gradle.kts
@@ -129,14 +129,13 @@ intellijPlatform {
             FailureLevel.NOT_DYNAMIC,
         )
         ides {
-            create(
-                type = IntelliJPlatformType.IntellijIdea,
-                version = "2026.2",
-            )
-            create(
-                type = IntelliJPlatformType.AndroidStudio,
-                version = "2026.2",
-            )
+            recommended()
+            select {
+                types = listOf(
+                    IntelliJPlatformType.IntellijIdea,
+                    IntelliJPlatformType.AndroidStudio
+                )
+            }
         }
     }
     signing {

--- a/tools/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/tools/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -28,7 +28,14 @@ Allows to create organized icon pack with an extension property of you pack obje
 ]]></description>
     <dependencies>
         <plugin id="org.jetbrains.kotlin"/>
-        <plugin id="com.intellij.modules.compose"/>
+
+        <module name="intellij.libraries.skiko"/>
+        <module name="intellij.platform.compose"/>
+        <module name="intellij.libraries.compose.foundation.desktop"/>
+        <module name="intellij.platform.jewel.foundation"/>
+        <module name="intellij.platform.jewel.ui"/>
+        <module name="intellij.platform.jewel.ideLafBridge"/>
+        <module name="intellij.libraries.compose.runtime.desktop"/>
     </dependencies>
 
     <actions>


### PR DESCRIPTION
Replace com.intellij.modules.compose with explicit platform module deps and add Android Studio to plugin verifier IDEs.

- closes: #1059

---

### 📝 Changelog

If this PR introduces user-facing changes, please update the relevant **Unreleased** section in changelogs:

- [ ] 🔌 [IntelliJ Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/idea-plugin/CHANGELOG.md)
- [ ] 🖥️ [CLI](https://github.com/ComposeGears/Valkyrie/blob/main/tools/cli/CHANGELOG.md)
- [ ] 🐘 [Gradle Plugin](https://github.com/ComposeGears/Valkyrie/blob/main/tools/gradle-plugin/CHANGELOG.md)
